### PR TITLE
Cite the non-obsolete JSON RFC

### DIFF
--- a/spec/apimodel.mdwn
+++ b/spec/apimodel.mdwn
@@ -10,7 +10,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 ## The JSON API model
 
-JSON is a text-based data interchange format as specified in [RFC4627](https://tools.ietf.org/html/rfc4627). All data sent from the client to the server or from the server to the client MUST be valid JSON according to the RFC, encoded in UTF-8.
+JSON is a text-based data interchange format as specified in [RFC7159](https://tools.ietf.org/html/rfc7159). All data sent from the client to the server or from the server to the client MUST be valid JSON according to the RFC, encoded in UTF-8.
 
 ### The structure of an exchange
 


### PR DESCRIPTION
[RFC 4627](https://tools.ietf.org/html/rfc4627) was obsoleted by [RFC 7159](https://tools.ietf.org/html/rfc7159).