### PR TITLE
Fix typos; Expand an abbreviation

### DIFF
--- a/client-guide/jmap-client-guide.mdwn
+++ b/client-guide/jmap-client-guide.mdwn
@@ -367,7 +367,7 @@ This is a good example of multiple method calls combined into a single request. 
 3. `getMessageUpdates`: Gets the list of ids for all messages which have been added or modified, plus the list of messages which have been deleted. We have also specified `fetchMessages` and `fetchMessageProperties` arguments here to request the standard header information we need to display a message in a mailbox for any new/changed messages. This includes all mutable properties of a message, so is sufficient to bring any changed messages up to date.
 4. `getThreadUpdates`: Gets the list of threads which have had messages added or removed from the thread. We also fetch the `Thread` object for those threads that have changed.
 
-In each case, the `sinceState` argument comes from the reponse to our previous calls to get the records of that type.
+In each case, the `sinceState` argument comes from the response to our previous calls to get the records of that type.
 
 ### Handling a standard response
 
@@ -553,7 +553,7 @@ The most common error will be a `tooManyChanges` error, when the number of chang
 
 `getThreadUpdates`: Just like with `getMessageUpdates`, if there are too many changes you can either flush your cache of threads, or try with a higher `maxChanges` but `fetchThreads: false`.
 
-In each of the error cases, a single futher HTTP request should be sufficient to get the necessary data to update the client to the correct state.
+In each of the error cases, a single further HTTP request should be sufficient to get the necessary data to update the client to the correct state.
 
 ### Handling message list without delta updates
 
@@ -582,7 +582,7 @@ Moving a message from the Inbox to the Trash is simple:
         }
     }, "call1" ]
 
-We can then do a resync as in section 4 to update the client cache. This is easy, but means there's a noticable delay performing every action, and we cannot operate in an offline mode and resync later. We can improve on this, although it makes it considerably more complicated. We can apply the effects we think the changes will have instantly then compare this with the results we get back from the server.
+We can then do a resync as in section 4 to update the client cache. This is easy, but means there's a noticeable delay performing every action, and we cannot operate in an offline mode and resync later. We can improve on this, although it makes it considerably more complicated. We can apply the effects we think the changes will have instantly then compare this with the results we get back from the server.
 
 1. **Mailbox counts**.
 
@@ -612,4 +612,4 @@ We can then do a resync as in section 4 to update the client cache. This is easy
 
 4. **Message object**. Update the `mailboxIds` property on the message object.
 
-When you next do resync, whether that's a second or several days later, apply the changes and fetch the delta update (as per section 4) in a single request, and when the response is received, undo the preemptive changes made above and apply the real changes. Hopefully the end result will be the same, and there will be no noticable difference to the user.
+When you next do resync, whether that's a second or several days later, apply the changes and fetch the delta update (as per section 4) in a single request, and when the response is received, undo the preemptive changes made above and apply the real changes. Hopefully the end result will be the same, and there will be no noticeable difference to the user.

--- a/home/faq.mdwn
+++ b/home/faq.mdwn
@@ -30,7 +30,7 @@ In IMAP, you can only have one mailbox but you can have multiple flags on a sing
 
 ## Why isUnread instead of isRead?
 
-Although this may seem inconsistent at first, it actually makes more sense. The "special" status is when a message is unread (this is what clients are interested in), so like isDraft, isFlagged and isAnswered, we make the special status equal to `true`. It is also consistant with the need for unread counts in mailbox objects, not read counts, and makes the definition of sorting a message list the same for isFlagged and isUnread when conversations are collapsed.
+Although this may seem inconsistent at first, it actually makes more sense. The "special" status is when a message is unread (this is what clients are interested in), so like isDraft, isFlagged and isAnswered, we make the special status equal to `true`. It is also consistent with the need for unread counts in mailbox objects, not read counts, and makes the definition of sorting a message list the same for isFlagged and isUnread when conversations are collapsed.
 
 ## I want to implement it. What do I need to know?
 

--- a/server-guide/jmap-server-guide.mdwn
+++ b/server-guide/jmap-server-guide.mdwn
@@ -91,11 +91,11 @@ For each message, store:
  
 ### 5. Message index
 
-For searching messages at any reasonable speed, an index is required from textual content within the message to the message id. Describing how this should work is beyone the scope of this guide. 
+For searching messages at any reasonable speed, an index is required from textual content within the message to the message id. Describing how this should work is beyond the scope of this guide.
 
 ### 6. Messages
 
-A map of GUID (sha1 of the message contents) to the raw RFC2822 message itself. This is the bulk of the data to be stored for each user. As this data is immutable and referenced by its sha1, there are many possibilities for how to store it. Each message ould be stored as a separate file using its GUID as the name. Or on a separate networked object store etc. etc.
+A map of GUID (sha1 of the message contents) to the raw RFC2822 message itself. This is the bulk of the data to be stored for each user. As this data is immutable and referenced by its sha1, there are many possibilities for how to store it. Each message could be stored as a separate file using its GUID as the name. Or on a separate networked object store etc. etc.
  
 ### 7. Message log
 
@@ -133,7 +133,7 @@ This is solely used to look up the conversation to assign to a message on creati
 
 The suggested rule for connecting messages into threads is this:
 
-If two messages share a common RFC2822 Message Id in the set of such ids within the `Message-Id`, `References` and `In-Reply-To` headers of each message, and the messages have the same `Subject` header (after stripping any preceeding Re:/Fwd: and trimmming white space from either end), then they should belong in the same thread. Otherwise they should belong in different threads.
+If two messages share a common RFC2822 Message Id in the set of such ids within the `Message-Id`, `References` and `In-Reply-To` headers of each message, and the messages have the same `Subject` header (after stripping any preceding Re:/Fwd: and trimming white space from either end), then they should belong in the same thread. Otherwise they should belong in different threads.
 
 ## Message List Algorithms
 

--- a/server-guide/jmap-server-guide.mdwn
+++ b/server-guide/jmap-server-guide.mdwn
@@ -34,7 +34,7 @@ There are three types of data structures suggested in this guide (excluding the 
 
 This is a simple collection of important top-level values for the user (kept in a **Map**):
 
-- Highest ModSeq for the user (`63 bits` for IMAP compat)
+- Highest ModSeq for the user (`63 bits` for IMAP compatibility)
 - Highest ModSeq of any Mailbox.
 - Low watermark ModSeq for Thread Log `63 bits` – whenever the thread log (see below) is truncated, the modseq of the new first item in the log is stored here. Any attempt to call *getThreadUpdates* with a modseq lower than this must be rejected with a `cannotCalculateUpdates` error.
 - Low watermark ModSeq for Message Log `63 bits` – the same, but for the message log.
@@ -79,7 +79,7 @@ For each message, store:
 - **isFlagged** `1 bit` (mutable)
 - **isAnswered** `1 bit` (mutable)
 - **isDraft** `1 bit` (mutable by IMAP)
-- Other flags + labels + annotations as needed for IMAP compat only. (mutable)
+- Other flags + labels + annotations as needed for IMAP compatibility only. (mutable)
 - **Mailboxes** (list of mailbox ids this message belongs to) (mutable)
 - **From** header (either in the JSON used by JMAP, or whatever IMAP needs)
 - **To** header (either in the JSON used by JMAP, or whatever IMAP needs)

--- a/spec/apimodel.mdwn
+++ b/spec/apimodel.mdwn
@@ -16,7 +16,7 @@ JSON is a text-based data interchange format as specified in [RFC4627](https://t
 
 The client initiates an API request by sending the server a JSON array. Each element in this array is another array and constitutes passing a **message** to the server. The server will process this and return a response consisting of an array of messages in the same format. A message array always contains three elements:
 
-1. The **name** of the message, a `String` specifiying the method to be called on the server, or the type of response being sent to the client.
+1. The **name** of the message, a `String` specifying the method to be called on the server, or the type of response being sent to the client.
 2. An `Object` containing *named* **arguments** for that method or response.
 3. A **client id**, an arbitrary `String` to be echoed back with the responses emitted by that method call (as we'll see lower down, a method may return 1 or more responses, especially as some methods make implicit calls to other ones).
 
@@ -196,7 +196,7 @@ The following errors may be returned instead of the *fooUpdates* response:
 Modifying the state of Foo objects on the server is done via the *setFoos* method. This encompasses creating, updating and destroying Foo records. This has two benefits:
 
 1. It allows the server to sort out ordering and dependencies that may exist if doing multiple operations at once (for example to ensure there is always a minimum number of a certain record type).
-2. Only a single call is required to make all changes to a particuar type, so the *ifInState* requirement will not be invalidated by a previous method call in the same request.
+2. Only a single call is required to make all changes to a particular type, so the *ifInState* requirement will not be invalidated by a previous method call in the same request.
 
 The *setFoos* method takes the following arguments:
 

--- a/spec/authentication.mdwn
+++ b/spec/authentication.mdwn
@@ -101,7 +101,7 @@ Returned if the server is temporarily blocking this IP/client from authenticatin
 
 ### Refetching URL endpoints
 
-A server MAY (although SHOULD NOT) move end points for any services other than authentication at any time. If a request to the API/file upload/event source endpoing returns a `404`, the client MUST refetch the URL endpoints. To do this, it should make an authenticated GET request to the authentication URL (see below for how to authenticate requests). This should return a `200` response, with a single JSON object containing the following properties:
+A server MAY (although SHOULD NOT) move end points for any services other than authentication at any time. If a request to the API/file upload/event source endpoint returns a `404`, the client MUST refetch the URL endpoints. To do this, it should make an authenticated GET request to the authentication URL (see below for how to authenticate requests). This should return a `200` response, with a single JSON object containing the following properties:
 
 - **api**: `String`
   The URL to use for JMAP API requests.

--- a/spec/calendar.mdwn
+++ b/spec/calendar.mdwn
@@ -107,7 +107,7 @@ The response to *setCalendars* is called *calendarsSet*. It has the following ar
 - **created**: `String[Calendar]` (optional)
   A map of the creation id to an object containing the **id** property for all successfully created calendars, omitted if none.
 - **updated**: `String[]` (optional)
-  A list of ids for gropus that were successfully updated, omitted if none.
+  A list of ids for groups that were successfully updated, omitted if none.
 - **destroyed**: `String[]` (optional)
   A list of ids for calendars that were successfully destroyed, omitted if none.
 - **notCreated**: `String[SetError]` (optional)

--- a/spec/calendareventlist.mdwn
+++ b/spec/calendareventlist.mdwn
@@ -40,15 +40,15 @@ A **FilterCondition** object has the following properties:
 - **text**: `String` (optional)
   Looks for the text in the *summary*, *description*, *location*, *organizer*, *attendees* properties of the event or any recurrence of the event (matching either name or email in the organizer/attendee case).
 - **summary**: `String` (optional)
-  Looks for the text in the *summary* property of the event, or the overriden *summary* property of a recurrence.
+  Looks for the text in the *summary* property of the event, or the overridden *summary* property of a recurrence.
 - **description**: `String` (optional)
-  Looks for the text in the *description* property of the event, or the overriden *description* property of a recurrence.
+  Looks for the text in the *description* property of the event, or the overridden *description* property of a recurrence.
 - **location**: `String` (optional)
-  Looks for the text in the *location* property of the event, or the overriden *location* property of a recurrence.
+  Looks for the text in the *location* property of the event, or the overridden *location* property of a recurrence.
 - **organizer**: `String` (optional)
-  Looks for the text in the name or email fields of the *organizer* property of the event, or the overriden *organizer* property of a recurrence.
+  Looks for the text in the name or email fields of the *organizer* property of the event, or the overridden *organizer* property of a recurrence.
 - **attendee**: `String` (optional)
-  Looks for the text in the name or email of any item in the *attendees* property of the event, or the overriden *attendees* property of a recurrence.
+  Looks for the text in the name or email of any item in the *attendees* property of the event, or the overridden *attendees* property of a recurrence.
 
 The exact semantics for matching `String` fields is **deliberately not defined** to allow for flexibility in indexing implementation, subject to the following:
 

--- a/spec/contactgroup.mdwn
+++ b/spec/contactgroup.mdwn
@@ -101,7 +101,7 @@ The response to *setContactGroups* is called *contactGroupsSet*. It has the foll
 - **created**: `String[Contact]` (optional)
   A map of the creation id to an object containing the **id** property for all successfully created groups, omitted if none.
 - **updated**: `String[]` (optional)
-  A list of ids for gropus that were successfully updated, omitted if none.
+  A list of ids for groups that were successfully updated, omitted if none.
 - **destroyed**: `String[]` (optional)
   A list of ids for groups that were successfully destroyed, omitted if none.
 - **notCreated**: `String[SetError]` (optional)

--- a/spec/message.mdwn
+++ b/spec/message.mdwn
@@ -262,7 +262,7 @@ The properties of the Message object submitted for creation MUST conform to the 
 - **size**: This MUST NOT be included. It is set by the server upon creation.
 - **preview**: This MUST NOT be included. It is set by the server upon creation.
 - **textBody**: Optional. If not supplied and an htmlBody is, the server SHOULD generate a text version for the message from this.
-- **htmlBody**: Optional. If this contains internal links (cid:) the cid value should be the attacment id.
+- **htmlBody**: Optional. If this contains internal links (cid:) the cid value should be the attachment id.
 - **attachments**: Optional. An array of Attachment objects detailing all the attachments to the message. To add an attachment, the file must first be uploaded using the standard upload mechanism; this will give the client a URL that may be used to identify the file. The `id` property may be assigned by the client, and is solely used for matching up with `cid:<id>` links inside the `htmlBody`. The server MAY (and probably will) change the ids upon sending.
  
   If one of the attachments is not found, the creation MUST be rejected with an `invalidProperties` error. An extra property SHOULD be included in the error object called `attachmentsNotFound`, of type `String[]`, which should be an array of the ids of any attachments that could not be found on the server.

--- a/spec/searchsnippet.mdwn
+++ b/spec/searchsnippet.mdwn
@@ -9,7 +9,7 @@ A **SearchSnippet** object has the following properties:
 - **subject**: `String|null`
   If text from the filter matches the subject, this is the subject of the message HTML-escaped, with matching words/phrases wrapped in `<b></b>` tags. If it does not match, this is `null`.
 - **preview**: `String|null`
-  If text from the filter matches the plain-text or HTML body, this is the relevant section of the body (converted to plain text if originaly HTML), HTML-escaped, with matching words/phrases wrapped in `<b></b>` tags, up to 256 characters long. If it does not match, this is `null`.
+  If text from the filter matches the plain-text or HTML body, this is the relevant section of the body (converted to plain text if originally HTML), HTML-escaped, with matching words/phrases wrapped in `<b></b>` tags, up to 256 characters long. If it does not match, this is `null`.
 
 It is server-defined what is a relevant section of the body for preview. If the server is unable to determine search snippets, it MUST just return `null` for both the *subject* and *preview* properties.
 

--- a/spec/upload.mdwn
+++ b/spec/upload.mdwn
@@ -6,7 +6,7 @@ The server will respond with one of the following HTTP response codes:
 
 #### `201`: File uploaded successfully
 
-The content of the reponse is a single JSON object with the following properties:
+The content of the response is a single JSON object with the following properties:
 
 - **url**: `String`,
   The file can be redownloaded from this link (the request MUST be authenticated as per any HTTP request). This is also used to identify the file internally when attached to drafts etc.


### PR DESCRIPTION
AFAIK, none of these are American/Commonwealth English spelling differences.