### PR TITLE
Rename fetchFoos/fetchFooProperties to fetchRecords/fetchRecordProperties

### DIFF
--- a/client-guide/jmap-client-guide.mdwn
+++ b/client-guide/jmap-client-guide.mdwn
@@ -316,8 +316,8 @@ To efficiently stay in sync, we can call:
     [
         [ "getMailboxUpdates", {
             sinceState: "m123456789",
-            fetchMailboxes: true,
-            fetchMailboxProperties: null
+            fetchRecords: true,
+            fetchRecordProperties: null
         }, "call1" ],
         [ "getMessageListUpdates", {
             filter: {
@@ -332,8 +332,8 @@ To efficiently stay in sync, we can call:
         [ "getMessageUpdates", {
             sinceState: "m815034"
             maxChanges: 30,
-            fetchMessages: true,
-            properties: [
+            fetchRecords: true,
+            fetchRecordProperties: [
                 "threadId",
                 "mailboxIds",
                 "isUnread",
@@ -352,7 +352,7 @@ To efficiently stay in sync, we can call:
         [ "getThreadUpdates", {
             sinceState: "mc1264092"
             maxChanges: 20,
-            fetchThreads: true
+            fetchRecords: true
         }, "call4" ]
     ]
 

--- a/spec/apimodel.mdwn
+++ b/spec/apimodel.mdwn
@@ -140,10 +140,10 @@ When the state of the set of Foo records changes on the server (whether due to c
   The current state of the client. This is the string that was returned as the *state* argument in the *foos* response. The server will return the changes made since this state.
 - **maxChanges**: `Number` (optional)
   The maximum number of changed Foos to return in the response. See below for a more detailed description.
-- **fetchFoos**: `Boolean`
+- **fetchRecords**: `Boolean`
   If `true`, after outputting the *fooUpdates* response, the server will make an implicit call to *getFoos* with the *changed* property of the response as the *ids* argument.
-- **fetchFooProperties**: `String[]|null`
-  If the *getFoos* method takes a *properties* argument, this argument is passed through on implicit calls (see the *fetchFoos* argument).
+- **fetchRecordProperties**: `String[]|null`
+  If the *getFoos* method takes a *properties* argument, this argument is passed through on implicit calls (see the *fetchRecords* argument).
 
 If there are too many changes on the server and the client is only keeping a partial cache, it may be more efficient for the client to just invalidate its entire cache and fetch what it needs on demand. The *maxChanges* argument allows the client to tell the server the maximum number of changes to send back. The server will return a `tooManyChanges` error if the number of changes exceeds the *maxChanges* argument. The client can treat this like a `cannotCalculateChanges` error and invalidate its entire Foo cache.
 
@@ -164,7 +164,7 @@ The following errors may be returned instead of the *fooUpdates* response:
 
 `invalidArguments`: Returned if the request does not include one of the required arguments, or one of the arguments is of the wrong type, or otherwise invalid. A *description* property MAY be present on the response object to help debug with an explanation of what the problem was.
 
-`tooManyChanges`: Returned if there are more changes the the client's *maxChanges* argument. The client can either invalidate its Foo cache or perhaps try again with a higher *maxChanges* argument but `fetchFoos: false`.
+`tooManyChanges`: Returned if there are more changes the the client's *maxChanges* argument. The client can either invalidate its Foo cache or perhaps try again with a higher *maxChanges* argument but `fetchRecords: false`.
 
 `cannotCalculateChanges`: Returned if the server cannot calculate the changes from the state string given by the client. Usually due to the client's state being too old. The client MUST invalidate its Foo cache.
 

--- a/spec/calendar.mdwn
+++ b/spec/calendar.mdwn
@@ -49,7 +49,7 @@ The *getCalendarUpdates* call allows a client to efficiently update the state of
   The id of the account to use for this call. If omitted, the primary account will be used.
 - **sinceState**: `String`
   The current state of the client. This is the string that was returned as the *state* argument in the *calendars* response. The server will return the changes made since this state.
-- **fetchCalendars**: `Boolean`
+- **fetchRecords**: `Boolean`
   If `true`, after outputting a *calendarUpdates* response, an implicit call will be made to *getCalendars* with the *changed* property of the response as the *ids* argument.
 
 The response to *getCalendarUpdates* is called *calendarUpdates*. It has the following arguments:

--- a/spec/calendarevent.mdwn
+++ b/spec/calendarevent.mdwn
@@ -183,9 +183,9 @@ The *getCalendarEventUpdates* call allows a client to efficiently update the sta
   The id of the account to use for this call. If omitted, the primary account will be used.
 - **sinceState**: `String`
   The current state of the client. This is the string that was returned as the *state* argument in the *calendarEvents* response. The server will return the changes made since this state.
-- **fetchCalendarEvents**: `Boolean`
-  If `true`, after outputting a *calendarEventUpdates* response, an implicit call will be made to *getCalendarEvents* with the *changed* property of the response as the *ids* argument, and the *fetchCalendarEventProperties* argument as the *properties* argument.
-- **fetchCalendarEventProperties**: `String[]|null`
+- **fetchRecords**: `Boolean`
+  If `true`, after outputting a *calendarEventUpdates* response, an implicit call will be made to *getCalendarEvents* with the *changed* property of the response as the *ids* argument, and the *fetchRecordProperties* argument as the *properties* argument.
+- **fetchRecordProperties**: `String[]|null`
   Passed through as the *properties* argument to any implicit *getCalendarEvents* call.
 
 The response to *getCalendarEventUpdates* is called *calendarEventUpdates*. It has the following arguments:

--- a/spec/contact.mdwn
+++ b/spec/contact.mdwn
@@ -139,9 +139,9 @@ The *getContactUpdates* call allows a client to efficiently update the state of 
   The id of the account to use for this call. If omitted, the primary account will be used.
 - **sinceState**: `String`
   The current state of the client. This is the string that was returned as the *state* argument in the *contacts* response. The server will return the changes made since this state.
-- **fetchContacts**: `Boolean`
+- **fetchRecords**: `Boolean`
   If `true`, after outputting a *contactUpdates* response, an implicit call will be made to *getContacts* with the *changed* property of the response as the *ids* argument, and the *fetchContactProperties* argument as the *properties* argument.
-- **fetchContactProperties**: `String[]|null`
+- **fetchRecordProperties**: `String[]|null`
   Passed through as the *properties* argument to any implicit *getContacts* call.
 
 The response to *getContactUpdates* is called *contactUpdates*. It has the following arguments:

--- a/spec/contactgroup.mdwn
+++ b/spec/contactgroup.mdwn
@@ -45,7 +45,7 @@ The *getContactGroupUpdates* call allows a client to efficiently update the stat
   The id of the account to use for this call. If omitted, the primary account will be used.
 - **sinceState**: `String`
   The current state of the client. This is the string that was returned as the *state* argument in the *contactGroups* response. The server will return the changes made since this state.
-- **fetchContactGroups**: `Boolean`
+- **fetchRecords**: `Boolean`
   If `true`, after outputting a *contactGroupUpdates* response, an implicit call will be made to *getContactGroups* with the *changed* property of the response as the *ids* argument.
 
 The response to *getContactGroupUpdates* is called *contactGroupUpdates*. It has the following arguments:

--- a/spec/mailbox.mdwn
+++ b/spec/mailbox.mdwn
@@ -109,9 +109,9 @@ The *getMailboxUpdates* call allows a client to efficiently update the state of 
   The id of the account to use for this call. If omitted, the primary account will be used.
 - **sinceState**: `String`
   The current state of the client. This is the string that was returned as the *state* argument in the *mailboxes* response. The server will return the changes made since this state.
-- **fetchMailboxes**: `Boolean`
+- **fetchRecords**: `Boolean`
   If `true`, after outputting a *mailboxUpdates* response, an implicit call will be made to *getMailboxes* with the *changed* property of the response as the *ids* argument, and the *fetchMailboxProperties* argument as the *properties* argument.
-- **fetchMailboxProperties**: `String[]|null`
+- **fetchRecordProperties**: `String[]|null`
   If `null`, all Mailbox properties will be fetched unless *onlyCountsChanged* in the *mailboxUpdates* response is `true`, in which case only the 4 counts properties will be returned (*totalMessages*, *unreadMessages*, *totalThreads* and *unreadThreads*). If not `null`, this value will be passed through to the *getMailboxes* call regardless of the *onlyCountsChanged* value in the *mailboxUpdates* response.
 
 The response to *getMailboxUpdates* is called *mailboxUpdates*. It has the following arguments:

--- a/spec/message.mdwn
+++ b/spec/message.mdwn
@@ -176,9 +176,9 @@ The *getMessageUpdates* call allows a client to efficiently update the state of 
   The current state of the client. This is the string that was returned as the *state* argument in the *messages* response. The server will return the changes made since this state.
 - **maxChanges**: `Number` (optional)
   The maximum number of changed messages to return in the response. See below for a more detailed description.
-- **fetchMessages**: `Boolean`
-  If true, after outputting a *messageUpdates* response, an implicit call will be made to *getMessages* with a list of all message ids in the *changed* argument of the response as the *ids* argument, and the *fetchMessageProperties* argument as the *properties* argument.
-- **fetchMessageProperties**: `String[]|null`
+- **fetchRecords**: `Boolean`
+  If true, after outputting a *messageUpdates* response, an implicit call will be made to *getMessages* with a list of all message ids in the *changed* argument of the response as the *ids* argument, and the *fetchRecordProperties* argument as the *properties* argument.
+- **fetchRecordProperties**: `String[]|null`
   The list of properties to fetch on any fetched messages. See *getMessages* for a full description.
 
 The response to *getMessageUpdates* is called *messageUpdates*. It has the following arguments:
@@ -204,7 +204,7 @@ The following errors may be returned instead of the *messageUpdates* response:
 
 `invalidArguments`: Returned if the request does not include one of the required arguments, or one of the arguments is of the wrong type, or otherwise invalid. A *description* property MAY be present on the response object to help debug with an explanation of what the problem was.
 
-`tooManyChanges`: Returned if there are more changes the the client's *maxChanges* argument. The client MAY retry with a higher max changes, (but with `fetchMessages:false` perhaps to limit the data transfer). Alternatively, the client can invalidate its Message cache.
+`tooManyChanges`: Returned if there are more changes the the client's *maxChanges* argument. The client MAY retry with a higher max changes, (but with `fetchRecords:false` perhaps to limit the data transfer). Alternatively, the client can invalidate its Message cache.
 
 `cannotCalculateChanges`: Returned if the server cannot calculate the changes from the state string given by the client. Usually due to the client's state being too old. The client MUST not try to call *getMessageUpdates* again with the same *oldState*, and instead MUST invalidate its Message cache.
 

--- a/spec/thread.mdwn
+++ b/spec/thread.mdwn
@@ -87,10 +87,10 @@ The *getThreadUpdates* call allows a client to efficiently update the state of a
   The current state of the client. This is the string that was returned as the *state* argument in the *threads* response. The server will return the changes made since this state.
 - **maxChanges**: `Number` (optional)
   The maximum number of changed threads to return in the response. See below for a more detailed description.
-- **fetchThreads**: `Boolean`
+- **fetchRecords**: `Boolean`
   If `true`, after outputting a *threadUpdates* response, an implicit call will be made to *getThreads* with the *changed* property of the response as the *ids* argument, and *fetchMessages* equal to `false`.
 
-If there are too many changes on the server and the client is only keeping a partial cache, it may be more efficient for the client to just invalidate its entire cache and fetch what it needs on demand. The *maxChanges* argument allows the client to tell the server the maximum number of changes to send back. The server will return a `tooManyChanges` error if the number of changes exceeds the *maxChanges* argument. The client can either invalidate its Thread cache or perhaps try again with a higher *maxChanges* argument but `fetchThreads: false`.
+If there are too many changes on the server and the client is only keeping a partial cache, it may be more efficient for the client to just invalidate its entire cache and fetch what it needs on demand. The *maxChanges* argument allows the client to tell the server the maximum number of changes to send back. The server will return a `tooManyChanges` error if the number of changes exceeds the *maxChanges* argument. The client can either invalidate its Thread cache or perhaps try again with a higher *maxChanges* argument but `fetchRecords: false`.
 
 The response to *getThreadUpdates* is called *threadUpdates*. It has the following arguments:
 
@@ -116,6 +116,6 @@ The following errors may be returned instead of the *threadUpdates* response:
 
 `invalidArguments`: Returned if the request does not include one of the required arguments, or one of the arguments is of the wrong type, or otherwise invalid. A *description* property MAY be present on the response object to help debug with an explanation of what the problem was.
 
-`tooManyChanges`: Returned if there are more changes the the client's *maxChanges* argument. The client MAY retry with a higher max changes, (but with `fetchThreads:false` perhaps to limit the data transfer). Alternatively, the client can invalidate its Thread cache.
+`tooManyChanges`: Returned if there are more changes the the client's *maxChanges* argument. The client MAY retry with a higher max changes, (but with `fetchRecords:false` perhaps to limit the data transfer). Alternatively, the client can invalidate its Thread cache.
 
 `cannotCalculateChanges`: Returned if the server cannot calculate the changes from the state string given by the client. Usually due to the client's state being too old. The client MUST invalidate its Thread cache.


### PR DESCRIPTION
Having the record type embedded in the property name makes it difficult to store method parameters in a standalone object because you need to know the record type to serialise/deserialise correctly.