### PR TITLE
Make use of nulls and optional properties more consistent

### DIFF
--- a/spec/account.mdwn
+++ b/spec/account.mdwn
@@ -36,7 +36,7 @@ TODO:
 
 To fetch the complete list of accounts to which the user has access, make a call to `getAccounts`. It takes a sole, optional argument:
 
-- **sinceState**: `String` (optional)
+- **sinceState**: `String|null`
   This is the `state` string from a previous call to *getAccounts*.
 
 The response to *getAccounts* is called *accounts*. It has the following arguments:

--- a/spec/apimodel.mdwn
+++ b/spec/apimodel.mdwn
@@ -106,6 +106,10 @@ Where the API specifies `Date` as a type, it means a string in [RFC3339](https:/
 
 Where the API specifies `LocalDate` as a type, it means a string in the same format as `Date`, but with the `Z` omitted from the end. This only occurs in relation to calendar event recurrences, due to the need for them to be expanded and interpreted in local time for a particular time zone. The interpretation in absolute time depends upon the time zone for the event, which MAY not be a fixed offset (for example when daylight savings occurs). 
 
+### Use of `null`
+
+Unless otherwise noted, a missing property in a request, response or object MUST be intepreted exactly the same as that property having the value `null` If `null` is not a valid value for that property this would typically cause an error to occur. This rule does not apply to the [top-level datatypes](#data-model-overview), where a missing property usually indicates that the sender wants to leave the existing property value untouched (eg in a [`setFoos`](#setfoos) request or a [`getFooUpdates`](#getfooupdates) response.
+
 ### CRUD methods
 
 JMAP defines various types of objects and provides a uniform interface for creating, retrieving, updating and deleting them. A **data type** is a collection of named, typed properties, just like the schema for a database table. Each row of the table is a **record**. For a `Foo` data type, records of that type would be fetched via a `getFoos` call and modified via a `setFoos` call. Delta updates may be fetched via a `getFooUpdates` call. These methods all follow a standard format as described below.
@@ -116,21 +120,21 @@ Objects of type **Foo** are fetched via a call to *getFoos*. Methods starting wi
 
 This method may take some or all of the following arguments. The getter for a particular data type may not implement all of the arguments (for example if the data type only has two properties, there is little point in being able to just return one of them etc.); see the docs of the type in question. However, if one of the following arguments is available, it will behave exactly as specified below.
 
-- **ids**: `String[]`
-  The ids of the Foo objects to return. For data types where there will never be that many records this may be optional, in which case **all** records of the data type are returned if it is omitted.
+- **ids**: `String[]|null`
+  The ids of the Foo objects to return. If `null` then **all** records of the data type are returned.
 - **properties**: `String[]|null`
   If supplied, only the properties listed in the array are returned for each Foo object. If `null`, all properties of the object are returned. The id of the object is **always** returned, even if not explicitly requested. For compatibility with possible future extensions, the server MUST simply ignore any unknown properties in the list.
-- **sinceState**: `String` (optional)
+- **sinceState**: `String|null`
   The *state* argument from a *foos* response may be passed back to future *getFoos* calls as the *sinceState* argument. If the current state is the same, the server SHOULD skip fetching the records and return a result indicating there is no change (this is essentially like an ETag). Most types support the more sophisticated *getFooUpdates* call instead to allow for delta updates. However, for small collections of data that change infrequently, this might be used. If available, this argument is always optional.
 
 The response to `getFoos` is called `foos`. It has the following arguments:
 
 - **state**: `String`
   A string representing the state on the server for **all** the data of this type. If the data changes, this string will change. It is used to get delta updates, if supported for the type.
-- **list**: `Foo[]|null`
+- **list**: `Foo[]`
   An array of the Foo objects requested. This is the **empty array** if no objects were requested, or none were found. If *sinceState* was supplied and it is identical to the current state, this property is `null`.
 - **notFound**: `String[]|null`
-  This array contains the ids passed to the method for records that do not exist.
+  This array contains the ids passed to the method for records that do not exist, or `null` if all requested ids were found. It will always be `null` if the *ids* argument in the call was `null`.
 
 ### getFooUpdates
 
@@ -138,10 +142,10 @@ When the state of the set of Foo records changes on the server (whether due to c
 
 - **sinceState**: `String`
   The current state of the client. This is the string that was returned as the *state* argument in the *foos* response. The server will return the changes made since this state.
-- **maxChanges**: `Number` (optional)
+- **maxChanges**: `Number|null`
   The maximum number of changed Foos to return in the response. See below for a more detailed description.
-- **fetchRecords**: `Boolean`
-  If `true`, after outputting the *fooUpdates* response, the server will make an implicit call to *getFoos* with the *changed* property of the response as the *ids* argument.
+- **fetchRecords**: `Boolean|null`
+  If `true`, after outputting the *fooUpdates* response, the server will make an implicit call to *getFoos* with the *changed* property of the response as the *ids* argument. If `false` or `null`, no implicit call will be made.
 - **fetchRecordProperties**: `String[]|null`
   If the *getFoos* method takes a *properties* argument, this argument is passed through on implicit calls (see the *fetchRecords* argument).
 
@@ -177,14 +181,14 @@ Modifying the state of Foo objects on the server is done via the *setFoos* metho
 
 The *setFoos* method takes the following arguments:
 
-- **ifInState**: `String` (optional)
-  This is a state string as returned by the *getFoos* method. It is always optional to supply this argument. If supplied, the string must match the current state, otherwise the method will be aborted and a `stateMismatch` error returned.
-- **create**: `String[Foo]` (optional)
-  A map of *creation id* (an arbitrary string set by the client) to Foo objects (containing all properties except the id, unless otherwise stated in the specific documentation of the data type).
-- **update**: `String[Foo]` (optional)
-  A map of id to a Foo object. The object may omit any property; only properties that have changed need be included.
-- **destroy**: `String[]` (optional)
-  A list of ids for Foo objects to permanently delete.
+- **ifInState**: `String|null`
+  This is a state string as returned by the *getFoos* method. If supplied, the string must match the current state, otherwise the method will be aborted and a `stateMismatch` error returned. If `null`, the change will be applied to the current state.
+- **create**: `String[Foo]|null`
+  A map of *creation id* (an arbitrary string set by the client) to Foo objects (containing all properties except the id, unless otherwise stated in the specific documentation of the data type). If `null`, no objects will be created.
+- **update**: `String[Foo]|null`
+  A map of id to a Foo object. The object may omit any property; only properties that have changed need be included. If `null`, no objects will be updated.
+- **destroy**: `String[]|null`
+  A list of ids for Foo objects to permanently delete. If `null`, no objects will be deleted.
 
 Each create, update or destroy is considered an atomic unit. It is permissible for the server to commit some of the changes but not others, however it is not permissible to only commit part of an update to a single record (e.g. update a *name* property but not a *count* property, if both are supplied in the update object).
 
@@ -198,24 +202,24 @@ The response to *setFoos* is called *foosSet*. It has the following arguments:
   The state string that would have been returned by *getFoos* before making the requested changes, or `null` if the server doesn't know what the previous state string was.
 - **newState**: `String`
   The state string that will now be returned by *getFoos*.
-- **created**: `String[Foo]` (optional)
-  A map of the creation id to an object containing any **server-assigned** properties of the Foo object (including the id) for all successfully created records, omitted if none.
-- **updated**: `String[]` (optional)
-  A list of Foo ids for records that were successfully updated, omitted if none.
-- **destroyed**: `String[]` (optional)
-  A list of Foo ids for records that were successfully destroyed, omitted if none.
-- **notCreated**: `String[SetError]` (optional)
-  A map of creation id to a SetError object for each record that failed to be created, omitted if none. The possible errors are defined in the description of the method for specific data types.
-- **notUpdated**: `String[SetError]` (optional)
-  A map of Foo id to a SetError object for each record that failed to be updated, omitted if none. The possible errors are defined in the description of the method for specific data types.
-- **notDestroyed**: `String[SetError]` (optional)
-  A map of Foo id to a SetError object for each record that failed to be destroyed, omitted if none. The possible errors are defined in the description of the method for specific data types.
+- **created**: `String[Foo]`
+  A map of the creation id to an object containing any **server-assigned** properties of the Foo object (including the id) for all successfully created records.
+- **updated**: `String[]`
+  A list of Foo ids for records that were successfully updated.
+- **destroyed**: `String[]`
+  A list of Foo ids for records that were successfully destroyed.
+- **notCreated**: `String[SetError]`
+  A map of creation id to a SetError object for each record that failed to be created. The possible errors are defined in the description of the method for specific data types.
+- **notUpdated**: `String[SetError]`
+  A map of Foo id to a SetError object for each record that failed to be updated. The possible errors are defined in the description of the method for specific data types.
+- **notDestroyed**: `String[SetError]`
+  A map of Foo id to a SetError object for each record that failed to be destroyed. The possible errors are defined in the description of the method for specific data types.
 
 A **SetError** object has the following properties:
 
 - **type**: `String`
   The type of error.
-- **description**: `String` (optional)
+- **description**: `String|null`
   A description of the error to display to the user.
 
 Other properties may also be present on the object, as described in the relevant methods.

--- a/spec/calendar.mdwn
+++ b/spec/calendar.mdwn
@@ -17,10 +17,10 @@ A **Calendar** object has the following properties:
 
 Calendars can either be fetched explicitly by id, or all of them at once. To fetch calendars, make a call to `getCalendars`. It takes the following arguments:
 
-- **accountId**: `String` (optional)
-  The Account to fetch the calendars for. If omitted, the primary account is used.
-- **ids**: `String` (optional)
-  The ids of the calendars to fetch. If omitted, all calendars in the account are be fetched.
+- **accountId**: `String|null`
+  The Account to fetch the calendars for. If `null`, the primary account is used.
+- **ids**: `String|null`
+  The ids of the calendars to fetch. If `null`, all calendars in the account are be fetched.
 
 The response to *getCalendars* is called *calendars*. It has the following arguments:
 
@@ -31,7 +31,7 @@ The response to *getCalendars* is called *calendars*. It has the following argum
 - **list**: `Calendar[]`
   An array of the Calendar objects requested. This will be the **empty array** if none were requested, or none were found.
 - **notFound**: `String[]|null`
-  This array contains the ids passed to the method for calendars that do not exist, or `null` if all requested ids were found. It will always be `null` if the *ids* argument was omitted from the call.
+  This array contains the ids passed to the method for calendars that do not exist, or `null` if all requested ids were found. It will always be `null` if the *ids* argument in the call was `null`.
 
 The following errors may be returned instead of the *calendars* response:
 
@@ -45,12 +45,12 @@ The following errors may be returned instead of the *calendars* response:
 
 The *getCalendarUpdates* call allows a client to efficiently update the state of its cached calendars to match the new state on the server. It takes the following arguments:
 
-- **accountId**: `String` (optional)
-  The id of the account to use for this call. If omitted, the primary account will be used.
+- **accountId**: `String|null`
+  The id of the account to use for this call. If `null`, the primary account will be used.
 - **sinceState**: `String`
   The current state of the client. This is the string that was returned as the *state* argument in the *calendars* response. The server will return the changes made since this state.
-- **fetchRecords**: `Boolean`
-  If `true`, after outputting a *calendarUpdates* response, an implicit call will be made to *getCalendars* with the *changed* property of the response as the *ids* argument.
+- **fetchRecords**: `Boolean|null`
+  If `true`, after outputting a *calendarUpdates* response, an implicit call will be made to *getCalendars* with the *changed* property of the response as the *ids* argument. If `false` or `null`, no implicit call will be made.
 
 The response to *getCalendarUpdates* is called *calendarUpdates*. It has the following arguments:
 
@@ -83,13 +83,13 @@ Modifying the state of Calendar objects on the server is done via the *setCalend
 
 The *setCalendars* method takes the following arguments:
 
-- **ifInState**: `String` (optional)
+- **ifInState**: `String|null`
   This is a state string as returned by the *getCalendars* method. If supplied, the string must match the current state, otherwise the method will be aborted and a `stateMismatch` error returned.
-- **create**: `String[Calendar]` (optional)
+- **create**: `String[Calendar]|null`
   A map of *creation id* (an arbitrary string set by the client) to Calendar objects (containing all properties except the id).
-- **update**: `String[Calendar]` (optional)
+- **update**: `String[Calendar]|null`
   A map of id to a Calendar object. The object may omit any property; only properties that have changed need be included.
-- **destroy**: `String[]` (optional)
+- **destroy**: `String[]|null`
   A list of ids for Calendar objects to permanently delete.
 
 Each create, update or destroy is considered an atomic unit. It is permissible for the server to commit some of the changes but not others, however it is not permissible to only commit part of an update to a single calendar (e.g. update the *name* property but not the *isVisible* property if both are supplied in the update object).
@@ -104,24 +104,24 @@ The response to *setCalendars* is called *calendarsSet*. It has the following ar
   The state string that would have been returned by *getCalendars* before making the requested changes, or `null` if the server doesn't know what the previous state string was.
 - **newState**: `String`
   The state string that will now be returned by *getCalendars*.
-- **created**: `String[Calendar]` (optional)
-  A map of the creation id to an object containing the **id** property for all successfully created calendars, omitted if none.
-- **updated**: `String[]` (optional)
-  A list of ids for groups that were successfully updated, omitted if none.
-- **destroyed**: `String[]` (optional)
-  A list of ids for calendars that were successfully destroyed, omitted if none.
-- **notCreated**: `String[SetError]` (optional)
-  A map of creation id to a SetError object for each calendar that failed to be created, omitted if none. The possible errors are defined in the description of the method for specific data types.
-- **notUpdated**: `String[SetError]` (optional)
-  A map of Calendar id to a SetError object for each calendar that failed to be updated, omitted if none. The possible errors are defined in the description of the method for specific data types.
-- **notDestroyed**: `String[SetError]` (optional)
-  A map of Calendar id to a SetError object for each calendar that failed to be destroyed, omitted if none. The possible errors are defined in the description of the method for specific data types.
+- **created**: `String[Calendar]`
+  A map of the creation id to an object containing the **id** property for all successfully created calendars.
+- **updated**: `String[]`
+  A list of ids for groups that were successfully updated.
+- **destroyed**: `String[]`
+  A list of ids for calendars that were successfully destroyed.
+- **notCreated**: `String[SetError]`
+  A map of creation id to a SetError object for each calendar that failed to be created. The possible errors are defined in the description of the method for specific data types.
+- **notUpdated**: `String[SetError]`
+  A map of Calendar id to a SetError object for each calendar that failed to be updated. The possible errors are defined in the description of the method for specific data types.
+- **notDestroyed**: `String[SetError]`
+  A map of Calendar id to a SetError object for each calendar that failed to be destroyed. The possible errors are defined in the description of the method for specific data types.
 
 A **SetError** object has the following properties:
 
 - **type**: `String`
   The type of error.
-- **description**: `String` (optional)
+- **description**: `String|null`
   A description of the error to display to the user.
 
 If any of the properties in a create or update are invalid (immutable, wrong type, invalid value for the property – like a zero-length *name*), the server MUST reject the create/update with a SetError of type `invalidProperties`. The SetError object SHOULD contain a property called *properties* of type `String[]` that lists **all** the properties that were invalid. The object MAY also contain a *description* property of type `String` with a user-friendly description of the problems.

--- a/spec/calendarevent.mdwn
+++ b/spec/calendarevent.mdwn
@@ -135,18 +135,18 @@ A **File** Object has the following properties:
 
 - **url**: `String`
   A url to download the attachment. The HTTP request must be authenticated (see the Authenticating HTTP Requests section).
-- **type**: `String` (optional)
+- **type**: `String|null`
   The content-type of the attachment, if known.
-- **name**: `String` (optional)
+- **name**: `String|null`
   The full file name, if known. e.g. "myworddocument.doc"
-- **size**: `Number` (optional)
+- **size**: `Number|null`
   The size, in bytes, of the attachment when fully decoded (i.e. the number of bytes in the file the user would download), if known.
 
 ### getCalendarEvents
 
 CalendarEvents can only be fetched explicitly by id. To fetch events, make a call to `getCalendarEvents`. It takes the following arguments:
 
-- **accountId**: `String` (optional)
+- **accountId**: `String|null`
   The id of the account to use for this call. If not given, defaults to the primary account.
 - **ids**: `String[]`
   An array of ids for the events to fetch.
@@ -179,12 +179,12 @@ The following errors may be returned instead of the *events* response:
 
 The *getCalendarEventUpdates* call allows a client to efficiently update the state of its cached calendar events to match the new state on the server. It takes the following arguments:
 
-- **accountId**: `String` (optional)
-  The id of the account to use for this call. If omitted, the primary account will be used.
+- **accountId**: `String|null`
+  The id of the account to use for this call. If `null`, the primary account will be used.
 - **sinceState**: `String`
   The current state of the client. This is the string that was returned as the *state* argument in the *calendarEvents* response. The server will return the changes made since this state.
-- **fetchRecords**: `Boolean`
-  If `true`, after outputting a *calendarEventUpdates* response, an implicit call will be made to *getCalendarEvents* with the *changed* property of the response as the *ids* argument, and the *fetchRecordProperties* argument as the *properties* argument.
+- **fetchRecords**: `Boolean|null`
+  If `true`, after outputting a *calendarEventUpdates* response, an implicit call will be made to *getCalendarEvents* with the *changed* property of the response as the *ids* argument, and the *fetchRecordProperties* argument as the *properties* argument. If `false` or `null`, no implicit call will be made.
 - **fetchRecordProperties**: `String[]|null`
   Passed through as the *properties* argument to any implicit *getCalendarEvents* call.
 
@@ -219,13 +219,13 @@ Modifying the state of CalendarEvent objects on the server is done via the *setC
 
 The *setCalendarEvents* method takes the following arguments:
 
-- **ifInState**: `String` (optional)
-  This is a state string as returned by the *getCalendarEvents* method. If supplied, the string must match the current state, otherwise the method will be aborted and a `stateMismatch` error returned.
-- **create**: `String[CalendarEvent]` (optional)
+- **ifInState**: `String|null`
+  This is a state string as returned by the *getCalendarEvents* method. If supplied, the string must match the current state, otherwise the method will be aborted and a `stateMismatch` error returned. If `null`, the change will be applied to the current state.
+- **create**: `String[CalendarEvent]|null`
   A map of *creation id* (an arbitrary string set by the client) to CalendarEvent objects (containing all properties except the id).
-- **update**: `String[CalendarEvent]` (optional)
+- **update**: `String[CalendarEvent]|null`
   A map of id to a CalendarEvent object. The object may omit any property; only properties that have changed need be included.
-- **destroy**: `String[]` (optional)
+- **destroy**: `String[]|null`
   A list of ids for CalendarEvent objects to permanently delete.
 
 Each create, update or destroy is considered an atomic unit. It is permissible for the server to commit some of the changes but not others, however it is not permissible to only commit part of an update to a single event (e.g. update the *utcStart* property but not the *startTimeZone* property if both are supplied in the update object).
@@ -256,24 +256,24 @@ The response to *setCalendarEvents* is called *calendarEventsSet*. It has the fo
   The state string that would have been returned by *getCalendarEvents* before making the requested changes, or `null` if the server doesn't know what the previous state string was.
 - **newState**: `String`
   The state string that will now be returned by *getCalendarEvents*.
-- **created**: `String[CalendarEvent]` (optional)
-  A map of the creation id to an object containing the **id** property for all successfully created events, omitted if none.
-- **updated**: `String[]` (optional)
-  A list of ids for events that were successfully updated, omitted if none.
-- **destroyed**: `String[]` (optional)
-  A list of ids for events that were successfully destroyed, omitted if none.
-- **notCreated**: `String[SetError]` (optional)
-  A map of creation id to a SetError object for each event that failed to be created, omitted if none. The possible errors are defined in the description of the method for specific data types.
-- **notUpdated**: `String[SetError]` (optional)
-  A map of CalendarEvent id to a SetError object for each event that failed to be updated, omitted if none. The possible errors are defined in the description of the method for specific data types.
-- **notDestroyed**: `String[SetError]` (optional)
-  A map of CalendarEvent id to a SetError object for each event that failed to be destroyed, omitted if none. The possible errors are defined in the description of the method for specific data types.
+- **created**: `String[CalendarEvent]`
+  A map of the creation id to an object containing the **id** property for all successfully created events
+- **updated**: `String[]`
+  A list of ids for events that were successfully updated.
+- **destroyed**: `String[]`
+  A list of ids for events that were successfully destroyed.
+- **notCreated**: `String[SetError]`
+  A map of creation id to a SetError object for each event that failed to be created. The possible errors are defined in the description of the method for specific data types.
+- **notUpdated**: `String[SetError]`
+  A map of CalendarEvent id to a SetError object for each event that failed to be updated. The possible errors are defined in the description of the method for specific data types.
+- **notDestroyed**: `String[SetError]`
+  A map of CalendarEvent id to a SetError object for each event that failed to be destroyed. The possible errors are defined in the description of the method for specific data types.
 
 A **SetError** object has the following properties:
 
 - **type**: `String`
   The type of error.
-- **description**: `String` (optional)
+- **description**: `String|null`
   A description of the error to display to the user.
 
 If any of the properties in a create or update are invalid (immutable, wrong type, invalid value for the property – like a *calendarId* for a non-existent calendar), the server MUST reject the create/update with a SetError of type `invalidProperties`. The SetError object SHOULD contain a property called *properties* of type `String[]` that lists **all** the properties that were invalid. The object MAY also contain a *description* property of type `String` with a user-friendly description of the problems.

--- a/spec/calendareventlist.mdwn
+++ b/spec/calendareventlist.mdwn
@@ -6,16 +6,16 @@ A **CalendarEventList** is a query on the set of events in a user's calendars. T
 
 To fetch a calendar event list, make a call to *getCalendarEventList*. It takes the following arguments:
 
-- **accountId**: `String` (optional)
-  The id of the account to use for this call. If omitted, the primary account will be used.
-- **filter**: `FilterCondition|FilterOperator`
+- **accountId**: `String|null`
+  The id of the account to use for this call. If `null`, the primary account will be used.
+- **filter**: `FilterCondition|FilterOperator|null`
   Determines the set of events returned in the results. See the "Filtering" section below for allowed values and semantics.
-- **position**: `Number` (optional)
-  The 0-based index of the first result in the list to return, presumed `0` if omitted. If a negative value is given, the call MUST be rejected with an `invalidArguments` error.
-- **limit**: `Number` (optional)
-  The maximum number of results to return. No limit presumed if omitted. The server MAY choose to enforce a maximum `limit` argument. In this case, if a greater value is given (or if it is omitted), the limit should be clamped to the maximum; since the total number of results in the list is returned, the client can determine if it has received all the results. If a negative value is given, the call MUST be rejected with an `invalidArguments` error.
-- **fetchCalendarEvents**: `Boolean`
-  If `true` then after outputting a *calendarEventList* response, an implicit call will be made to *getCalendarEvents* with the `calendarEventIds` array in the response as the *ids* argument.
+- **position**: `Number|null`
+  The 0-based index of the first result in the list to return, presumed `0` if `null`. If a negative value is given, the call MUST be rejected with an `invalidArguments` error.
+- **limit**: `Number|null`
+  The maximum number of results to return. If `null`, no limit presumed. The server MAY choose to enforce a maximum `limit` argument. In this case, if a greater value is given (or if it is `null`), the limit should be clamped to the maximum; since the total number of results in the list is returned, the client can determine if it has received all the results. If a negative value is given, the call MUST be rejected with an `invalidArguments` error.
+- **fetchCalendarEvents**: `Boolean|null`
+  If `true` then after outputting a *calendarEventList* response, an implicit call will be made to *getCalendarEvents* with the `calendarEventIds` array in the response as the *ids* argument. If `false` or `null`, no implicit call will be made.
 
 #### Filtering
 
@@ -31,23 +31,23 @@ A **FilterOperator** object has the following properties:
 
 A **FilterCondition** object has the following properties:
 
-- **inCalendars**: `String[]` (optional)
+- **inCalendars**: `String[]|null`
   A list of calendar ids. An event must be in ANY of these calendars to match the condition.
-- **before**: `Date`  (optional)
+- **before**: `Date|null`
   The `utcStart` of the event, or any recurrence of the event, must be before this date to match the condition.
-- **after**: `Date` (optional)
+- **after**: `Date|null`
   The `utcEnd` of the event, or any recurrence of the event, must be after this date to match the condition.
-- **text**: `String` (optional)
+- **text**: `String|null`
   Looks for the text in the *summary*, *description*, *location*, *organizer*, *attendees* properties of the event or any recurrence of the event (matching either name or email in the organizer/attendee case).
-- **summary**: `String` (optional)
+- **summary**: `String|null`
   Looks for the text in the *summary* property of the event, or the overridden *summary* property of a recurrence.
-- **description**: `String` (optional)
+- **description**: `String|null`
   Looks for the text in the *description* property of the event, or the overridden *description* property of a recurrence.
-- **location**: `String` (optional)
+- **location**: `String|null`
   Looks for the text in the *location* property of the event, or the overridden *location* property of a recurrence.
-- **organizer**: `String` (optional)
+- **organizer**: `String|null`
   Looks for the text in the name or email fields of the *organizer* property of the event, or the overridden *organizer* property of a recurrence.
-- **attendee**: `String` (optional)
+- **attendee**: `String|null`
   Looks for the text in the name or email of any item in the *attendees* property of the event, or the overridden *attendees* property of a recurrence.
 
 The exact semantics for matching `String` fields is **deliberately not defined** to allow for flexibility in indexing implementation, subject to the following:
@@ -63,7 +63,7 @@ Results MUST be sorted in order of the *utcStart* property, oldest first.
 
 #### Windowing
 
-To paginate the results the client MAY supply a *position* argument: this is the 0-based index of the first result to return in the list of events after filtering and sorting. If the index is greater than or equal to the total number of events in the list, then there are no results to return, but this DOES NOT generate an error. If omitted, this defaults to `0`.
+To paginate the results the client MAY supply a *position* argument: this is the 0-based index of the first result to return in the list of events after filtering and sorting. If the index is greater than or equal to the total number of events in the list, then there are no results to return, but this DOES NOT generate an error. If `null`, this defaults to `0`.
 
 #### Response
 
@@ -71,7 +71,7 @@ The response to a call to *getCalendarEventList* is called *calendarEventList*. 
 
 - **accountId**: `String`
   The id of the account used for the call.
-- **filter**: `FilterCondition|FilterOperator`
+- **filter**: `FilterCondition|FilterOperator|null`
   The filter of the event list. Echoed back from the call.
 - **state**: `String`
   A string encoding the current state on the server. This string will change

--- a/spec/contact.mdwn
+++ b/spec/contact.mdwn
@@ -64,7 +64,7 @@ A **ContactInformation** object has the following properties:
 
 - **type**: `String`
   Specifies the context of the contact information. This MUST be taken from the set of values allowed depending on whether this is part of the *phones*, *emails* or *online* property (see above).
-- **label**: `String` (optional)
+- **label**: `String|null`
   A label describing the value in more detail, especially if `type === "other"` (but MAY be included with any type).
 - **value**: `String`
   The actual contact information, e.g. the email address or phone number.
@@ -75,7 +75,7 @@ An **Address** object has the following properties:
 
 - **type**: `String`
   Specifies the context of the contact information. This MUST be taken from the set of values allowed depending on whether this is part of the *phones*, *emails* or *online* property (see above).
-- **label**: `String` (optional)
+- **label**: `String|null`
   A label describing the value in more detail, especially if `type === "other"` (but MAY be included with any type).
 - **street**: `String`
   The street address. This MAY be multiple lines; newlines MUST be preserved.
@@ -94,21 +94,21 @@ A **File** Object has the following properties:
 
 - **url**: `String`
   A url to download the file. The HTTP request must be authenticated (see the Authenticating HTTP Requests section).
-- **type**: `String` (optional)
+- **type**: `String|null`
   The content-type of the file, if known.
-- **name**: `String` (optional)
+- **name**: `String|null`
   The full file name, if known. e.g. "myface.png"
-- **size**: `Number` (optional)
+- **size**: `Number|null`
   The size, in bytes, of the file when fully decoded (i.e. the number of bytes in the file the user would download), if known.
 
 ### getContacts
 
 Contacts can either be fetched explicitly by id, or all of them at once. To fetch contacts, make a call to `getContacts`. It takes the following arguments:
 
-- **accountId**: `String` (optional)
-  The Account to fetch the contacts for. If omitted, the primary account is used.
-- **ids**: `String` (optional)
-  The ids of the contacts to fetch. If omitted, all contacts in the account are be fetched.
+- **accountId**: `String|null`
+  The Account to fetch the contacts for. If `null`, the primary account is used.
+- **ids**: `String|null`
+  The ids of the contacts to fetch. If `null`, all contacts in the account are be fetched.
 - **properties**: `String[]|null`
   If supplied, only the properties listed in the array will be returned for each contact. If `null`, all properties are returned. The id of the contact will **always** be returned, even if not explicitly requested. For compatibility with possible future extensions, the server MUST simply ignore any unknown properties in the list.
 
@@ -121,7 +121,7 @@ The response to *getContacts* is called *contacts*. It has the following argumen
 - **list**: `Contact[]`
   An array of the Contact objects requested. This will be the **empty array** if none were requested, or none were found.
 - **notFound**: `String[]|null`
-  This array contains the ids passed to the method for contacts that do not exist, or `null` if all requested ids were found. It will always be `null` if the *ids* argument was omitted from the call.
+  This array contains the ids passed to the method for contacts that do not exist, or `null` if all requested ids were found. It will always be `null` if the *ids* argument in the call was `null`.
 
 The following errors may be returned instead of the *contacts* response:
 
@@ -135,12 +135,12 @@ The following errors may be returned instead of the *contacts* response:
 
 The *getContactUpdates* call allows a client to efficiently update the state of its cached contacts to match the new state on the server. It takes the following arguments:
 
-- **accountId**: `String` (optional)
-  The id of the account to use for this call. If omitted, the primary account will be used.
+- **accountId**: `String|null`
+  The id of the account to use for this call. If `null`, the primary account will be used.
 - **sinceState**: `String`
   The current state of the client. This is the string that was returned as the *state* argument in the *contacts* response. The server will return the changes made since this state.
-- **fetchRecords**: `Boolean`
-  If `true`, after outputting a *contactUpdates* response, an implicit call will be made to *getContacts* with the *changed* property of the response as the *ids* argument, and the *fetchRecordProperties* argument as the *properties* argument.
+- **fetchRecords**: `Boolean|null`
+  If `true`, after outputting a *contactUpdates* response, an implicit call will be made to *getContacts* with the *changed* property of the response as the *ids* argument, and the *fetchRecordProperties* argument as the *properties* argument. If `false` or `null`, no implicit call is made.
 - **fetchRecordProperties**: `String[]|null`
   Passed through as the *properties* argument to any implicit *getContacts* call.
 
@@ -175,13 +175,13 @@ Modifying the state of Contact objects on the server is done via the *setContact
 
 The *setContacts* method takes the following arguments:
 
-- **ifInState**: `String` (optional)
-  This is a state string as returned by the *getContacts* method. If supplied, the string must match the current state, otherwise the method will be aborted and a `stateMismatch` error returned.
-- **create**: `String[Contact]` (optional)
+- **ifInState**: `String|null`
+  This is a state string as returned by the *getContacts* method. If supplied, the string must match the current state, otherwise the method will be aborted and a `stateMismatch` error returned. If `null`, the change will be applied to the current state.
+- **create**: `String[Contact]|null`
   A map of *creation id* (an arbitrary string set by the client) to Contact objects (containing all properties except the id).
-- **update**: `String[Contact]` (optional)
+- **update**: `String[Contact]|null`
   A map of id to a Contact object. The object may omit any property; only properties that have changed need be included.
-- **destroy**: `String[]` (optional)
+- **destroy**: `String[]|null`
   A list of ids for Contact objects to permanently delete.
 
 Each create, update or destroy is considered an atomic unit. It is permissible for the server to commit some of the changes but not others, however it is not permissible to only commit part of an update to a single contact (e.g. update the *firstName* property but not the *lastName* property if both are supplied in the update object).
@@ -196,24 +196,24 @@ The response to *setContacts* is called *contactsSet*. It has the following argu
   The state string that would have been returned by *getContacts* before making the requested changes, or `null` if the server doesn't know what the previous state string was.
 - **newState**: `String`
   The state string that will now be returned by *getContacts*.
-- **created**: `String[Contact]` (optional)
-  A map of the creation id to an object containing the **id** property for all successfully created contacts, omitted if none.
-- **updated**: `String[]` (optional)
-  A list of ids for contacts that were successfully updated, omitted if none.
-- **destroyed**: `String[]` (optional)
-  A list of ids for contacts that were successfully destroyed, omitted if none.
-- **notCreated**: `String[SetError]` (optional)
-  A map of creation id to a SetError object for each contact that failed to be created, omitted if none. The possible errors are defined in the description of the method for specific data types.
-- **notUpdated**: `String[SetError]` (optional)
-  A map of Contact id to a SetError object for each contact that failed to be updated, omitted if none. The possible errors are defined in the description of the method for specific data types.
-- **notDestroyed**: `String[SetError]` (optional)
-  A map of Contact id to a SetError object for each contact that failed to be destroyed, omitted if none. The possible errors are defined in the description of the method for specific data types.
+- **created**: `String[Contact]`
+  A map of the creation id to an object containing the **id** property for all successfully created contacts.
+- **updated**: `String[]`
+  A list of ids for contacts that were successfully updated.
+- **destroyed**: `String[]`
+  A list of ids for contacts that were successfully destroyed.
+- **notCreated**: `String[SetError]`
+  A map of creation id to a SetError object for each contact that failed to be created. The possible errors are defined in the description of the method for specific data types.
+- **notUpdated**: `String[SetError]`
+  A map of Contact id to a SetError object for each contact that failed to be updated. The possible errors are defined in the description of the method for specific data types.
+- **notDestroyed**: `String[SetError]`
+  A map of Contact id to a SetError object for each contact that failed to be destroyed. The possible errors are defined in the description of the method for specific data types.
 
 A **SetError** object has the following properties:
 
 - **type**: `String`
   The type of error.
-- **description**: `String` (optional)
+- **description**: `String|null`
   A description of the error to display to the user.
 
 Other properties may also be present on the object, as described in the relevant methods.

--- a/spec/contactgroup.mdwn
+++ b/spec/contactgroup.mdwn
@@ -13,10 +13,10 @@ A **Contact Group** represents a named set of contacts. It has the following pro
 
 Contact Groups can either be fetched explicitly by id, or all of them at once. To fetch contact groups, make a call to `getContactGroups`. It takes the following arguments:
 
-- **accountId**: `String` (optional)
-  The Account to fetch the groups for. If omitted, the primary account is used.
-- **ids**: `String` (optional)
-  The ids of the groups to fetch. If omitted, all contact groups in the account are be fetched.
+- **accountId**: `String|null`
+  The Account to fetch the groups for. If `null`, the primary account is used.
+- **ids**: `String|null`
+  The ids of the groups to fetch. If `null`, all contact groups in the account are be fetched.
 
 The response to *getContactGroups* is called *contactGroups*. It has the following arguments:
 
@@ -27,7 +27,7 @@ The response to *getContactGroups* is called *contactGroups*. It has the followi
 - **list**: `ContactGroup[]`
   An array of the ContactGroup objects requested. This will be the **empty array** if none were requested, or none were found.
 - **notFound**: `String[]|null`
-  This array contains the ids passed to the method for groups that do not exist, or `null` if all requested ids were found. It will always be `null` if the *ids* argument was omitted from the call.
+  This array contains the ids passed to the method for groups that do not exist, or `null` if all requested ids were found. It will always be `null` if the *ids* argument in the call was `null`.
 
 The following errors may be returned instead of the *contactGroups* response:
 
@@ -41,12 +41,12 @@ The following errors may be returned instead of the *contactGroups* response:
 
 The *getContactGroupUpdates* call allows a client to efficiently update the state of its cached contacts to match the new state on the server. It takes the following arguments:
 
-- **accountId**: `String` (optional)
-  The id of the account to use for this call. If omitted, the primary account will be used.
+- **accountId**: `String|null`
+  The id of the account to use for this call. If `null`, the primary account will be used.
 - **sinceState**: `String`
   The current state of the client. This is the string that was returned as the *state* argument in the *contactGroups* response. The server will return the changes made since this state.
-- **fetchRecords**: `Boolean`
-  If `true`, after outputting a *contactGroupUpdates* response, an implicit call will be made to *getContactGroups* with the *changed* property of the response as the *ids* argument.
+- **fetchRecords**: `Boolean|null`
+  If `true`, after outputting a *contactGroupUpdates* response, an implicit call will be made to *getContactGroups* with the *changed* property of the response as the *ids* argument. If `false` or `null`, no implicit call will be made.
 
 The response to *getContactGroupUpdates* is called *contactGroupUpdates*. It has the following arguments:
 
@@ -79,13 +79,13 @@ Modifying the state of ContactGroup objects on the server is done via the *setCo
 
 The *setContactGroups* method takes the following arguments:
 
-- **ifInState**: `String` (optional)
-  This is a state string as returned by the *getContactGroups* method. If supplied, the string must match the current state, otherwise the method will be aborted and a `stateMismatch` error returned.
-- **create**: `String[ContactGroup]` (optional)
+- **ifInState**: `String|null`
+  This is a state string as returned by the *getContactGroups* method. If supplied, the string must match the current state, otherwise the method will be aborted and a `stateMismatch` error returned. If `null`, the change will be applied to the current state.
+- **create**: `String[ContactGroup]|null`
   A map of *creation id* (an arbitrary string set by the client) to ContactGroup objects (containing all properties except the id).
-- **update**: `String[ContactGroup]` (optional)
+- **update**: `String[ContactGroup]|null`
   A map of id to a ContactGroup object. The object may omit any property; only properties that have changed need be included.
-- **destroy**: `String[]` (optional)
+- **destroy**: `String[]|null`
   A list of ids for ContactGroup objects to permanently delete.
 
 Each create, update or destroy is considered an atomic unit. It is permissible for the server to commit some of the changes but not others, however it is not permissible to only commit part of an update to a single group (e.g. update the *name* property but not the *contactIds* property if both are supplied in the update object).
@@ -102,24 +102,24 @@ The response to *setContactGroups* is called *contactGroupsSet*. It has the foll
   The state string that would have been returned by *getContactGroups* before making the requested changes, or `null` if the server doesn't know what the previous state string was.
 - **newState**: `String`
   The state string that will now be returned by *getContactGroups*.
-- **created**: `String[Contact]` (optional)
-  A map of the creation id to an object containing the **id** property for all successfully created groups, omitted if none.
-- **updated**: `String[]` (optional)
-  A list of ids for groups that were successfully updated, omitted if none.
-- **destroyed**: `String[]` (optional)
-  A list of ids for groups that were successfully destroyed, omitted if none.
-- **notCreated**: `String[SetError]` (optional)
-  A map of creation id to a SetError object for each group that failed to be created, omitted if none. The possible errors are defined in the description of the method for specific data types.
-- **notUpdated**: `String[SetError]` (optional)
-  A map of ContactGroup id to a SetError object for each group that failed to be updated, omitted if none. The possible errors are defined in the description of the method for specific data types.
-- **notDestroyed**: `String[SetError]` (optional)
-  A map of ContactGroup id to a SetError object for each group that failed to be destroyed, omitted if none. The possible errors are defined in the description of the method for specific data types.
+- **created**: `String[Contact]`
+  A map of the creation id to an object containing the **id** property for all successfully created groups.
+- **updated**: `String[]`
+  A list of ids for groups that were successfully updated.
+- **destroyed**: `String[]`
+  A list of ids for groups that were successfully destroyed.
+- **notCreated**: `String[SetError]`
+  A map of creation id to a SetError object for each group that failed to be created. The possible errors are defined in the description of the method for specific data types.
+- **notUpdated**: `String[SetError]`
+  A map of ContactGroup id to a SetError object for each group that failed to be updated. The possible errors are defined in the description of the method for specific data types.
+- **notDestroyed**: `String[SetError]`
+  A map of ContactGroup id to a SetError object for each group that failed to be destroyed. The possible errors are defined in the description of the method for specific data types.
 
 A **SetError** object has the following properties:
 
 - **type**: `String`
   The type of error.
-- **description**: `String` (optional)
+- **description**: `String|null`
   A description of the error to display to the user.
 
 The following errors may be returned instead of the *contactGroupsSet* response:

--- a/spec/mailbox.mdwn
+++ b/spec/mailbox.mdwn
@@ -75,12 +75,12 @@ The server MAY support extra properties on the Mailbox object. To avoid conflict
 
 Mailboxes can either be fetched explicitly by id, or all of them at once. To fetch mailboxes, make a call to `getMailboxes`. It takes the following arguments:
 
-- **accountId**: `String|null` (optional)
-  The Account to fetch the mailboxes for. If omitted or `null`, the primary account is used.
-- **ids**: `String[]|null` (optional)
-  The ids of the mailboxes to fetch. If omitted or `null`, all mailboxes in the account are returned.
-- **properties**: `String[]|null` (optional)
-  The properties of each mailbox to fetch. If omitted or `null`, all properties are returned. The id of the mailbox will **always** be returned, even if not explicitly requested. For compatibility with future extensions, the server MUST ignore any unknown properties in the list.
+- **accountId**: `String|null`
+  The Account to fetch the mailboxes for. If `null`, the primary account is used.
+- **ids**: `String[]|null`
+  The ids of the mailboxes to fetch. If `null`, all mailboxes in the account are returned.
+- **properties**: `String[]|null`
+  The properties of each mailbox to fetch. If `null`, all properties are returned. The id of the mailbox will **always** be returned, even if not explicitly requested. For compatibility with future extensions, the server MUST ignore any unknown properties in the list.
 
 The response to *getMailboxes* is called *mailboxes*. It has the following arguments:
 
@@ -91,7 +91,7 @@ The response to *getMailboxes* is called *mailboxes*. It has the following argum
 - **list**: `Mailbox[]`
   An array of the Mailbox objects requested. This will be the **empty array** if none were requested, or none were found.
 - **notFound**: `String[]|null`
-  This array contains the ids passed to the method for mailboxes that do not exist, or `null` if all requested ids were found. It will always be `null` if the *ids* argument was omitted from the call.
+  This array contains the ids passed to the method for mailboxes that do not exist, or `null` if all requested ids were found. It will always be `null` if the *ids* argument in the call was `null`.
 
 The following errors may be returned instead of the *mailboxes* response:
 
@@ -105,12 +105,12 @@ The following errors may be returned instead of the *mailboxes* response:
 
 The *getMailboxUpdates* call allows a client to efficiently update the state of its cached mailboxes to match the new state on the server. It takes the following arguments:
 
-- **accountId**: `String` (optional)
-  The id of the account to use for this call. If omitted, the primary account will be used.
+- **accountId**: `String|null`
+  The id of the account to use for this call. If `null`, the primary account will be used.
 - **sinceState**: `String`
   The current state of the client. This is the string that was returned as the *state* argument in the *mailboxes* response. The server will return the changes made since this state.
-- **fetchRecords**: `Boolean`
-  If `true`, after outputting a *mailboxUpdates* response, an implicit call will be made to *getMailboxes* with the *changed* property of the response as the *ids* argument, and the *fetchRecordProperties* argument as the *properties* argument.
+- **fetchRecords**: `Boolean|null`
+  If `true`, after outputting a *mailboxUpdates* response, an implicit call will be made to *getMailboxes* with the *changed* property of the response as the *ids* argument, and the *fetchRecordProperties* argument as the *properties* argument. If `false` or `null`, no implicit call will be made.
 - **fetchRecordProperties**: `String[]|null`
   If `null`, all Mailbox properties will be fetched unless *onlyCountsChanged* in the *mailboxUpdates* response is `true`, in which case only the 4 counts properties will be returned (*totalMessages*, *unreadMessages*, *totalThreads* and *unreadThreads*). If not `null`, this value will be passed through to the *getMailboxes* call regardless of the *onlyCountsChanged* value in the *mailboxUpdates* response.
 
@@ -145,16 +145,16 @@ The following errors may be returned instead of the `mailboxUpdates` response:
 
 Mailboxes can be created, updated and destroyed using the *setMailboxes* method. The method takes the following arguments:
 
-- **accountId**: `String` (optional)
-  The id of the account to use for this call. If not given, defaults to the primary account.
-- **ifInState**: `String` (optional)
+- **accountId**: `String|null`
+  The id of the account to use for this call. If `null`, defaults to the primary account.
+- **ifInState**: `String|null`
   This is a state string as returned by the *getMailboxes* method. If supplied, the string must match the current state, otherwise the method will be aborted and a `stateMismatch` error returned.
-- **create**: `String[Mailbox]` (optional)
-  A map of *creation id* (an arbitrary string set by the client) to Mailbox objects.
-- **update**: `String[Mailbox]` (optional)
-  A map of id to a an object containing the properties to update for that Mailbox.
-- **destroy**: `String[]` (optional)
-  A list of ids for Mailboxes to permanently delete.
+- **create**: `String[Mailbox]|null`
+  A map of *creation id* (an arbitrary string set by the client) to Mailbox objects. If `null`, no objects will be created.
+- **update**: `String[Mailbox]|null`
+  A map of id to a an object containing the properties to update for that Mailbox. If `null`, no objects will be updated.
+- **destroy**: `String[]|null`
+  A list of ids for Mailboxes to permanently delete. If `null`, no objects will be deleted.
 
 Each create, update or destroy is considered an atomic unit. The server MAY commit some of the changes but not others, however MAY NOT only commit part of an update to a single record (e.g. update the *name* field but not the *parentId* field, if both are supplied in the update object).
 
@@ -168,10 +168,10 @@ The properties of the Mailbox object submitted for creation MUST conform to the 
 
 - The *id* property MUST NOT be present.
 - The *parentId* property MUST be either `null` or be a valid id for a mailbox for which the `mayCreateSub` property is `true`.
-- The *role* property is optional. If not present, it defaults to `null`. If present it MUST be either `null`, a valid role as listed in the Mailbox object specification, or prefixed by `"x-"`.
+- The *role* property MUST be either `null`, a valid role as listed in the Mailbox object specification, or prefixed by `"x-"`.
 - The *mustBeOnlyMailbox* property MUST NOT be present. This is server dependent and will be set by the server.
-- The *mayXXX* properties are optional. All default to `true`. If present, they MUST all be set to `true`. Restrictions may only be set by the server for system mailboxes, or when sharing mailboxes with other users (setting sharing is not defined yet in this spec).
-- The *totalMessages*, *unreadMessages*, *totalThreads* and *unreadThreads* properties are optional. If present they MUST all have a value of 0.
+- The *mayXXX* properties MUST NOT be present. Restrictions may only be set by the server for system mailboxes, or when sharing mailboxes with other users (setting sharing is not defined yet in this spec).
+- The *totalMessages*, *unreadMessages*, *totalThreads* and *unreadThreads* properties MUST NOT be present.
 
 If any of the properties are invalid, the server MUST reject the create with an `invalidProperties` error. The Error object SHOULD contain a property called *properties* of type `String[]` that lists **all** the properties that were invalid. The object MAY also contain a *description* property of type `String` with a user-friendly description of the problems.
 
@@ -236,18 +236,18 @@ The response to *setMailboxes* is called *mailboxesSet*. It has the following ar
   The state string that would have been returned by `getMailboxes` before making the requested changes, or `null` if the server doesn't know what the previous state string was.
 - **newState**: `String`
   The state string that will now be returned by `getMailboxes`.
-- **created**: `String[Mailbox]` (optional)
-  A map of the creation id to an object containing the **id** and **mustBeOnlyMailbox** properties for each successfully created Mailbox, omitted if none.
-- **updated**: `String[]` (optional)
-  A list of ids for Mailboxes that were successfully updated, omitted if none.
-- **destroyed**: `String[]` (optional)
-  A list of ids for Mailboxes that were successfully destroyed, omitted if none.
-- **notCreated**: `String[SetError]` (optional)
-  A map of creation id to a SetError object for each Mailbox that failed to be created, omitted if none. The possible errors are defined above.
-- **notUpdated**: `String[SetError]` (optional)
-  A map of Mailbox id to a SetError object for each Mailbox that failed to be updated, omitted if none. The possible errors are defined above.
-- **notDestroyed**: `String[SetError]` (optional)
-  A map of Mailbox id to a SetError object for each Mailbox that failed to be destroyed, omitted if none. The possible errors are defined above.
+- **created**: `String[Mailbox]`
+  A map of the creation id to an object containing the **id** and **mustBeOnlyMailbox** properties for each successfully created Mailbox.
+- **updated**: `String[]`
+  A list of ids for Mailboxes that were successfully updated.
+- **destroyed**: `String[]`
+  A list of ids for Mailboxes that were successfully destroyed.
+- **notCreated**: `String[SetError]`
+  A map of creation id to a SetError object for each Mailbox that failed to be created. The possible errors are defined above.
+- **notUpdated**: `String[SetError]`
+  A map of Mailbox id to a SetError object for each Mailbox that failed to be updated. The possible errors are defined above.
+- **notDestroyed**: `String[SetError]`
+  A map of Mailbox id to a SetError object for each Mailbox that failed to be destroyed. The possible errors are defined above.
 
 The following errors may be returned instead of the *mailboxesSet* response:
 

--- a/spec/message.mdwn
+++ b/spec/message.mdwn
@@ -97,16 +97,16 @@ An **Attachment** object has the following properties:
   The size, in bytes, of the attachment when fully decoded (i.e. the number of bytes in the file the user would download).
 - **isInline**: `Boolean`
   True if the attachment is referenced by a `cid:` link from within the HTML body of the message.
-- **width**: `Number` (optional)
+- **width**: `Number|null`
   The width (in px) of the image, if the attachment is an image.
-- **height**: `Number` (optional)
+- **height**: `Number|null`
   The height (in px) of the image, if the attachment is an image.
 
 ### getMessages
 
 Messages can only be fetched explicitly by id. To fetch messages, make a call to `getMessages`. It takes the following arguments:
 
-- **accountId**: `String` (optional)
+- **accountId**: `String|null`
   The id of the account to use for this call. If not given, defaults to the primary account.
 - **ids**: `String[]`
   An array of ids for the messages to fetch.
@@ -170,13 +170,13 @@ If a call to *getMessages* returns with a different *state* string in the respon
 
 The *getMessageUpdates* call allows a client to efficiently update the state of any cached messages to match the new state on the server. It takes the following arguments:
 
-- **accountId**: `String` (optional)
+- **accountId**: `String|null`
   The id of the account to use for this call. If not given, defaults to the primary account.
 - **sinceState**: `String`
   The current state of the client. This is the string that was returned as the *state* argument in the *messages* response. The server will return the changes made since this state.
-- **maxChanges**: `Number` (optional)
+- **maxChanges**: `Number|null`
   The maximum number of changed messages to return in the response. See below for a more detailed description.
-- **fetchRecords**: `Boolean`
+- **fetchRecords**: `Boolean|null`
   If true, after outputting a *messageUpdates* response, an implicit call will be made to *getMessages* with a list of all message ids in the *changed* argument of the response as the *ids* argument, and the *fetchRecordProperties* argument as the *properties* argument.
 - **fetchRecordProperties**: `String[]|null`
   The list of properties to fetch on any fetched messages. See *getMessages* for a full description.
@@ -220,15 +220,15 @@ The *setMessages* method encompasses:
 
 It takes the following arguments:
 
-- **accountId**: `String` (optional)
+- **accountId**: `String|null`
   The id of the account to use for this call. If not given, defaults to the primary account.
-- **ifInState**: `String` (optional)
+- **ifInState**: `String|null`
   This is a state string as returned by the *getMessages* method. If supplied, the string must match the current state, otherwise the method will be aborted and a `stateMismatch` error returned.
-- **create**: `String[Message]` (optional)
+- **create**: `String[Message]|null`
   A map of *creation id* (an arbitrary string set by the client) to Message objects (see below for a detailed description).
-- **update**: `String[Message]` (optional)
+- **update**: `String[Message]|null`
   A map of id to a an object containing the properties to update for that Message.
-- **destroy**: `String[]` (optional)
+- **destroy**: `String[]|null`
   A list of ids for Message objects to permanently delete.
 
 Each create, update or destroy is considered an atomic unit. It is permissible for the server to commit some of the changes but not others, however it is not permissible to only commit part of an update to a single record (e.g. update the *isFlagged* field but not the *mailboxIds* field, if both are supplied in the update object for a message).
@@ -321,18 +321,18 @@ The response to *setMessages* is called *messagesSet*. It has the following argu
   The state string that would have been returned by *getMessages* before making the requested changes, or `null` if the server doesn't know what the previous state string was.
 - **newState**: `String`
   The state string that will now be returned by *getMessages*.
-- **created**: `String[Message]` (optional)
-  A map of the creation id to an object containing the *id*, *threadId*, *rawUrl* and *size* properties for each successfully created Message, omitted if none.
-- **updated**: `String[]` (optional)
-  A list of Message ids for Messages that were successfully updated, omitted if none.
-- **destroyed**: `String[]` (optional)
-  A list of Message ids for Messages that were successfully destroyed, omitted if none.
-- **notCreated**: `String[SetError]` (optional)
-  A map of creation id to a SetError object for each Message that failed to be created, omitted if none. The possible errors are defined above.
-- **notUpdated**: `String[SetError]` (optional)
-  A map of Message id to a SetError object for each Message that failed to be updated, omitted if none. The possible errors are defined above.
-- **notDestroyed**: `String[SetError]` (optional)
-  A map of Message id to a SetError object for each Message that failed to be destroyed, omitted if none. The possible errors are defined above.
+- **created**: `String[Message]`
+  A map of the creation id to an object containing the *id*, *threadId*, *rawUrl* and *size* properties for each successfully created Message.
+- **updated**: `String[]`
+  A list of Message ids for Messages that were successfully updated.
+- **destroyed**: `String[]`
+  A list of Message ids for Messages that were successfully destroyed.
+- **notCreated**: `String[SetError]`
+  A map of creation id to a SetError object for each Message that failed to be created. The possible errors are defined above.
+- **notUpdated**: `String[SetError]`
+  A map of Message id to a SetError object for each Message that failed to be updated. The possible errors are defined above.
+- **notDestroyed**: `String[SetError]`
+  A map of Message id to a SetError object for each Message that failed to be destroyed. The possible errors are defined above.
 
 The following errors may be returned instead of the *messagesSet* response:
 
@@ -350,8 +350,8 @@ The following errors may be returned instead of the *messagesSet* response:
 
 The *importMessage* method adds an RFC2822 message to a user's set of messages. The message must first be uploaded as a file using the standard upload mechanism. It takes the following arguments:
 
-- **accountId**: `String` (optional)
-  The id of the account to use for this call. If not given, defaults to the primary account.
+- **accountId**: `String|null`
+  The id of the account to use for this call. If `null`, defaults to the primary account.
 - **file**: `String`
   The URL of the uploaded file (see the file upload section).
 - **mailboxIds** `String[]`
@@ -392,10 +392,10 @@ The following errors may be returned instead of the *messageImported* response:
 
 The only way to move messages **between** two different accounts is to copy them using the *copyMessages* method, then once the copy has succeeded, delete the original. It takes the following arguments:
 
-- **fromAccountId**: `String` (optional)
-  The id of the account to copy messages from. If omitted, defaults to the primary account.
-- **toAccountId**: `String` (optional)
-  The id of the account to copy messages to. If omitted, defaults to the primary account.
+- **fromAccountId**: `String|null`
+  The id of the account to copy messages from. If `null`, defaults to the primary account.
+- **toAccountId**: `String|null`
+  The id of the account to copy messages to. If `null`, defaults to the primary account.
 - **messages**: `String[MessageCopy]`
   A map of *creation id* to a MessageCopy object.
 
@@ -422,8 +422,8 @@ The response to *copyMessages* is called *messagesCopied*. It has the following 
   The id of the account messages were copied from.
 - **toAccountId**: `String`
   The id of the account messages were copied to.
-- **copied**: `String[Message]`
-  A map of the creation id to an object containing the *id*, *threadId*, *rawUrl* and *size* properties for each successfully copied Message, omitted if none.
+- **copied**: `String[Message]|null`
+  A map of the creation id to an object containing the *id*, *threadId*, *rawUrl* and *size* properties for each successfully copied Message.
 - **notCreated**: `String[SetError]|null`
   A map of creation id to a SetError object for each Message that failed to be copied, `null` if none.
 
@@ -455,7 +455,7 @@ Messages can be reported as spam or non-spam to help train the user's spam filte
 
 To report messages, make a call to *reportMessages*. It takes the following arguments:
 
-- **accountId**: `String` (optional)
+- **accountId**: `String|null`
   The id of the account to use for this call. If not given, defaults to the primary account.
 - **messageIds**: `String[]`
   The list of ids of messages to report.

--- a/spec/messagelist.mdwn
+++ b/spec/messagelist.mdwn
@@ -10,30 +10,30 @@ When the state changes on the server, a delta update can be requested to efficie
 
 To fetch a message list, make a call to *getMessageList*. It takes the following arguments:
 
-- **accountId**: `String` (optional)
-  The id of the account to use for this call. If omitted, the primary account will be used.
-- **filter**: `FilterCondition|FilterOperator`
+- **accountId**: `String|null`
+  The id of the account to use for this call. If `null`, the primary account will be used.
+- **filter**: `FilterCondition|FilterOperator|null`
   Determines the set of messages returned in the results. See the "Filtering" section below for allowed values and semantics.
-- **sort**: `String[]`
+- **sort**: `String[]|null`
   A list of Message property names to sort by. See the "Sorting" section below for allowed values and semantics.
-- **collapseThreads**: `Boolean`
-  If true, each thread will only be returned once in the resulting list, at the position of the first message in the list (given the filter and sort order) belonging to the thread.
-- **position**: `Number` (optional)
-  The 0-based index of the first result in the list to return. If a negative value is given, the call MUST be rejected with an `invalidArguments` error.
-- **anchor**: `String` (optional)
+- **collapseThreads**: `Boolean|null`
+  If true, each thread will only be returned once in the resulting list, at the position of the first message in the list (given the filter and sort order) belonging to the thread. If `false` or `null`, threads may be returned multiple times.
+- **position**: `Number|null`
+  The 0-based index of the first result in the list to return. If a negative value is given, the call MUST be rejected with an `invalidArguments` error. If `null, 0 is used.
+- **anchor**: `String|null`
   A Message id. The index of this message id will be used in combination with the `anchorOffset` argument to determine the index of the first result to return (see the "Windowing" section below for more details).
-- **anchorOffset**: `Number` (optional)
+- **anchorOffset**: `Number|null`
   The index of the anchor message relative to the index of the first result to return. This MAY be negative. For example, `-1` means the first message after the anchor message should be the first result in the results returned (see the "Windowing" section below for more details).
-- **limit**: `Number`
-  The maximum number of results to return. The server MAY choose to enforce a maximum `limit` argument. In this case, if a greater value is given, the limit should be clamped to the maximum; since the total number of results in the list is returned, the client should not be relying on how many results are returned to determine if it has reached the end of the list. If a negative value is given, the call MUST be rejected with an `invalidArguments` error.
-- **fetchThreads**: `Boolean`
-  If `true`, after outputting a *messageList* response, an implicit call will be made to *getThreads* with the *threadIds* array in the reponse as the *ids* argument, and the *fetchMessages* and *fetchMessageProperties* arguments passed straight through from the call to *getMessageList*.
-- **fetchMessages**: `Boolean`
-  If `true` and `fetchThreads == false`, then after outputting a *messageList* response, an implicit call will be made to *getMessages* with the `messageIds` array in the response as the *ids* argument, and the *fetchMessageProperties* argument as the *properties* argument.
+- **limit**: `Number|null`
+  The maximum number of results to return. If `null`, no limit is presumed. The server MAY choose to enforce a maximum `limit` argument. In this case, if a greater value is given, the limit should be clamped to the maximum; since the total number of results in the list is returned, the client should not be relying on how many results are returned to determine if it has reached the end of the list. If a negative value is given, the call MUST be rejected with an `invalidArguments` error.
+- **fetchThreads**: `Boolean|null`
+  If `true`, after outputting a *messageList* response, an implicit call will be made to *getThreads* with the *threadIds* array in the reponse as the *ids* argument, and the *fetchMessages* and *fetchMessageProperties* arguments passed straight through from the call to *getMessageList*. If `false` or `null`, no implicit call will be made.
+- **fetchMessages**: `Boolean|null`
+  If `true` and `fetchThreads == false`, then after outputting a *messageList* response, an implicit call will be made to *getMessages* with the `messageIds` array in the response as the *ids* argument, and the *fetchMessageProperties* argument as the *properties* argument. If `false` or `null`, no implicit call will be made.
 - **fetchMessageProperties**: `String[]|null`
   The list of properties to fetch on any fetched messages. See *getMessages* for a full description.
-- **fetchSearchSnippets**: `Boolean`
-  If `true`, then after outputting a *messageList* and making any other implicit calls, an implicit call will be made to *getSearchSnippets*. The *messageIds* array from the response will be used as the *messageIds* argument, and the *filter* argument will be passed straight through.
+- **fetchSearchSnippets**: `Boolean|null`
+  If `true`, then after outputting a *messageList* and making any other implicit calls, an implicit call will be made to *getSearchSnippets*. The *messageIds* array from the response will be used as the *messageIds* argument, and the *filter* argument will be passed straight through. If `false` or `null`, no implicit call will be made.
 
 #### Filtering
 
@@ -49,43 +49,43 @@ A **FilterOperator** object has the following properties:
 
 A **FilterCondition** object has the following properties:
 
-- **inMailboxes**: `String[]` (optional)
+- **inMailboxes**: `String[]|null`
   A list of mailbox ids. A message must be in ALL of these mailboxes to match the condition.
-- **notInMailboxes**: `String[]` (optional)
+- **notInMailboxes**: `String[]|null`
   A list of mailbox ids. A message must NOT be in ANY of these mailboxes to match the condition.
-- **before**: `Date` (optional)
+- **before**: `Date|null`
   The date of the message (as returned on the Message object) must be before this date to match the condition.
-- **after**: `Date` (optional)
+- **after**: `Date|null`
   The date of the message (as returned on the Message object) must be on or after this date to match the condition.
-- **minSize**: `Number` (optional)
+- **minSize**: `Number|null`
   The size of the message in bytes (as returned on the Message object) must be equal to or greater than this number to match the condition.
-- **maxSize**: `Number` (optional)
+- **maxSize**: `Number|null`
   The size of the message in bytes (as returned on the Message object) must be less than this number to match the condition.
-- **isFlagged**: `Boolean` (optional)
+- **isFlagged**: `Boolean|null`
   The `isFlagged` property of the message must be identical to the value given to match the condition.
-- **isUnread**: `Boolean` (optional)
+- **isUnread**: `Boolean|null`
   The `isUnread` property of the message must be identical to the value given to match the condition.
-- **isAnswered**: `Boolean` (optional)
+- **isAnswered**: `Boolean|null`
   The `isAnswered` property of the message must be identical to the value given to match the condition.
-- **isDraft**: `Boolean` (optional)
+- **isDraft**: `Boolean|null`
   The `isDraft` property of the message must be identical to the value given to match the condition.
-- **hasAttachment**: `Boolean` (optional)
+- **hasAttachment**: `Boolean|null`
   The `hasAttachment` property of the message must be identical to the value given to match the condition.
-- **text**: `String` (optional)
+- **text**: `String|null`
   Looks for the text in the *from*, *to*, *cc*, *bcc*, *subject*, *textBody* or *htmlBody* properties of the message.
-- **from**: `String` (optional)
+- **from**: `String|null`
   Looks for the text in the *from* property of the message.
-- **to**: `String` (optional)
+- **to**: `String|null`
   Looks for the text in the *to* property of the message.
-- **cc**: `String` (optional)
+- **cc**: `String|null`
   Looks for the text in the *cc* property of the message.
-- **bcc**: `String` (optional)
+- **bcc**: `String|null`
   Looks for the text in the *bcc* property of the message.
-- **subject**: `String` (optional)
+- **subject**: `String|null`
   Looks for the text in the *subject* property of the message.
-- **body**: `String` (optional)
+- **body**: `String|null`
   Looks for the text in the *textBody* or *htmlBody* property of the message.
-- **header**: `String[]` (optional)
+- **header**: `String[]|null`
   The array MUST contain either one or two elements. The first element is the name of the header to match against. The second (optional) element is the text to look for in the header. If not supplied, the message matches simply if it *has* a header of the given name.
 
 The exact semantics for matching `String` fields is **deliberately not defined** to allow for flexibility in indexing implementation, subject to the following:
@@ -98,7 +98,7 @@ The exact semantics for matching `String` fields is **deliberately not defined**
 
 #### Sorting
 
-The `sort` argument lists the properties to compare between two messages to determine which comes first in the sort. If two messages have an identical value for the first property, the next property will be considered and so on. If all properties are the same (this includes the case where an empty array is given as the argument), the sort order is server-dependent, but MUST be stable between calls to `getMessageList`.
+The `sort` argument lists the properties to compare between two messages to determine which comes first in the sort. If two messages have an identical value for the first property, the next property will be considered and so on. If all properties are the same (this includes the case where an empty array or `null` is given as the argument), the sort order is server-dependent, but MUST be stable between calls to `getMessageList`.
 
 Optionally, following the property name there can be a space and then either the string `asc` or `desc` to specify ascending or descending sort for that property. If not specified, it MUST default to **descending**.
 
@@ -142,15 +142,14 @@ The response to a call to *getMessageList* is called *messageList*. It has the f
 
 - **accountId**: `String`
   The id of the account used for the call.
-- **filter**: `FilterCondition|FilterOperator`
+- **filter**: `FilterCondition|FilterOperator|null`
   The filter of the message list. Echoed back from the call.
 - **sort**: `String[]`
   A list of Message property names used to sort by. Echoed back from the call.
 - **collapseThreads**: `Boolean`
   Echoed back from the call.
 - **state**: `String`
-  A string encoding the current state on the server. This string will change
-  if the results of the message list MAY have changed (for example, there has been a change to the state of the set of Messages; it does not guarantee that anything in the list has changed). It may be passed to *getMessageListUpdates* to efficiently get the set of changes from the previous state.
+  A string encoding the current state on the server. This string will change if the results of the message list MAY have changed (for example, there has been a change to the state of the set of Messages; it does not guarantee that anything in the list has changed). It may be passed to *getMessageListUpdates* to efficiently get the set of changes from the previous state.
   
   Should a client receive back a response with a different state string to a previous call, it MUST either throw away the currently cached list and fetch it again (note, this does not require fetching the messages again, just the list of ids) or, if the server supports it, call *getMessageListUpdates* to get the delta difference.
 - **canCalculateUpdates**: `Boolean`
@@ -180,28 +179,28 @@ The following errors may be returned instead of the `messageList` response:
 
 The `getMessageListUpdates` call allows a client to efficiently update the state of any cached message list to match the new state on the server. It takes the following arguments:
 
-- **accountId**: `String` (optional)
-  The id of the account to use for this call. If omitted, the primary account will be used.
-- **filter**: `FilterCondition|FilterOperator`
+- **accountId**: `String|null`
+  The id of the account to use for this call. If `null`, the primary account will be used.
+- **filter**: `FilterCondition|FilterOperator|null`
   The filter argument that was used with *getMessageList*.
-- **sort**: `String[]`
+- **sort**: `String[]|null`
   The sort argument that was used with *getMessageList*.
-- **collapseThreads**: `Boolean`
+- **collapseThreads**: `Boolean|null`
   The *collapseThreads* argument that was used with *getMessageList*.
 - **sinceState**: `String`
   The current state of the client. This is the string that was returned as the *state* argument in the *messageList* response. The server will return the changes made since this state.
-- **uptoMessageId**: `String|null` (optional)
+- **uptoMessageId**: `String|null`
   The message id of the last message in the list that the client knows about. In the common case of the client only having the first X ids cached, this allows the server to ignore changes further down the list the client doesn't care about.
-- **maxChanges**: `Number` (optional)
+- **maxChanges**: `Number|null`
   The maximum number of changes to return in the response. See below for a more detailed description.
 
 The response to *getMessageListUpdates* is called *messageListUpdates* It has the following arguments:
 
 - **accountId**: `String`
   The id of the account used for the call.
-- **filter**: `FilterCondition|FilterOperator`
+- **filter**: `FilterCondition|FilterOperator|null`
   The filter of the message list. Echoed back from the call.
-- **sort**: `String[]`
+- **sort**: `String[]|null`
   A list of Message property names used to sort by. Echoed back from the call.
 - **collapseThreads**: `Boolean`
   Echoed back from the call.

--- a/spec/push.mdwn
+++ b/spec/push.mdwn
@@ -11,21 +11,21 @@ When something changes on the server, the server pushes a small JSON object to t
 
 An **AccountState** object has the following properties:
 
-- **mailboxes**: `String` (optional)
-  The string that would be returned as the `state` argument in a `mailboxes` response. Omitted if and only if the account has no mail data.
-- **threads**: `String` (optional)
-  The string that would be returned as the `state` argument in a `threads` response. Omitted if and only if the account has no mail data.
-- **messages**: `String` (optional)
+- **mailboxes**: `String|null`
+  The string that would be returned as the `state` argument in a `mailboxes` response. `null` if and only if the account has no mail data.
+- **threads**: `String|null`
+  The string that would be returned as the `state` argument in a `threads` response. `null` if and only if the account has no mail data.
+- **messages**: `String|null`
   The string that would be returned as the `state` argument in a `messages` response. Note, if this has changed, the client needs to refresh
-  message lists too, since these are queries on message state. Omitted if and only if the account has no mail data.
-- **contactGroups**: `String` (optional)
-  The string that would be returned as the `state` argument in a `contactGroups` response. Omitted if and only if the account has no contact data.
-- **contacts**: `String` (optional)
-  The string that would be returned as the `state` argument in a `contacts` response. Omitted if and only if the account has no contact data.
-- **calendars**: `String` (optional)
-  The string that would be returned as the `state` argument in a `calendars` response. Omitted if and only if the account has no calendar data.
-- **calendarEvents**: `String` (optional)
-  The string that would be returned as the `state` argument in a `calendarEvents` response. Omitted if and only if the account has no calendar data.
+  message lists too, since these are queries on message state. `null` if and only if the account has no mail data.
+- **contactGroups**: `String|null`
+  The string that would be returned as the `state` argument in a `contactGroups` response. `null` if and only if the account has no contact data.
+- **contacts**: `String|null`
+  The string that would be returned as the `state` argument in a `contacts` response. `null` if and only if the account has no contact data.
+- **calendars**: `String|null`
+  The string that would be returned as the `state` argument in a `calendars` response. `null` if and only if the account has no calendar data.
+- **calendarEvents**: `String|null`
+  The string that would be returned as the `state` argument in a `calendarEvents` response. `null` if and only if the account has no calendar data.
 
 Upon receiving this data, the client can easily compare to the previous state strings to see whether data has changed for each type. The actual changes can then be efficiently fetched in a single standard API request (mainly using the *getFooUpdates* type methods).
 

--- a/spec/searchsnippet.mdwn
+++ b/spec/searchsnippet.mdwn
@@ -19,11 +19,11 @@ Note, unlike most data types, a SearchSnippet DOES NOT have a property called `i
 
 To fetch search snippets, make a call to `getSearchSnippets`. It takes the following arguments:
 
-- **accountId**: `String` (optional)
-  The id of the account to use for this call. If not given, defaults to the primary account.
+- **accountId**: `String|null`
+  The id of the account to use for this call. If `null`, defaults to the primary account.
 - **messageIds**: `String[]`
   The list of ids of messages to fetch the snippets for.
-- **filter**: `FilterOperator`
+- **filter**: `FilterCondition|FilterOperator|null`
   The same filter as passed to getMessageList; see the description of this method for details.
 
 The response to `getSearchSnippets` is called `searchSnippets`. It has the following arguments:

--- a/spec/thread.mdwn
+++ b/spec/thread.mdwn
@@ -19,12 +19,12 @@ A **Thread** object has the following properties:
 
 Threads can only be fetched explicitly by id. To fetch threads, make a call to *getThreads*. It takes the following arguments:
 
-- **accountId**: `String` (optional)
+- **accountId**: `String|null`
   The id of the account to use for this call. If not given, defaults to the primary account.
 - **ids**: `String[]`
   An array of ids for the threads to fetch.
-- **fetchMessages**: `Boolean`
-  If true, after outputting a *threads* response, an implicit call will be made to *getMessages* with a list of all message ids in the returned threads as the *ids* argument, and the *fetchMessageProperties* argument as the *properties* argument.
+- **fetchMessages**: `Boolean|null`
+  If true, after outputting a *threads* response, an implicit call will be made to *getMessages* with a list of all message ids in the returned threads as the *ids* argument, and the *fetchMessageProperties* argument as the *properties* argument. If `false` or `null`, no implicit call will be made.
 - **fetchMessageProperties**: `String[]|null`
   The list of properties to fetch on any fetched messages. See *getMessages* for a full description.
 
@@ -38,8 +38,7 @@ The response to *getThreads* is called *threads*. It has the following arguments
 - **list**: `Thread[]`
   An array of Thread objects for the requested thread ids. This may not be in the same order as the ids were in the request.
 - **notFound**: `String[]|null`
-  An array of thread ids requested which could not be found, or `null` if all
-  ids were found.
+  An array of thread ids requested which could not be found, or `null` if all ids were found.
 
 The following errors may be returned instead of the `threads` response:
 
@@ -81,13 +80,13 @@ When messages are created or deleted, new threads may be created, or the set of 
 
 The *getThreadUpdates* call allows a client to efficiently update the state of any cached threads to match the new state on the server. It takes the following arguments:
 
-- **accountId**: `String` (optional)
+- **accountId**: `String|null`
   The id of the account to use for this call. If not given, defaults to the primary account.
 - **sinceState**: `String`
   The current state of the client. This is the string that was returned as the *state* argument in the *threads* response. The server will return the changes made since this state.
-- **maxChanges**: `Number` (optional)
+- **maxChanges**: `Number|null`
   The maximum number of changed threads to return in the response. See below for a more detailed description.
-- **fetchRecords**: `Boolean`
+- **fetchRecords**: `Boolean|null`
   If `true`, after outputting a *threadUpdates* response, an implicit call will be made to *getThreads* with the *changed* property of the response as the *ids* argument, and *fetchMessages* equal to `false`.
 
 If there are too many changes on the server and the client is only keeping a partial cache, it may be more efficient for the client to just invalidate its entire cache and fetch what it needs on demand. The *maxChanges* argument allows the client to tell the server the maximum number of changes to send back. The server will return a `tooManyChanges` error if the number of changes exceeds the *maxChanges* argument. The client can either invalidate its Thread cache or perhaps try again with a higher *maxChanges* argument but `fetchRecords: false`.


### PR DESCRIPTION
Original thinking (@neilj, @brong, you've already seen this):

* In top-level datatypes (eg Message, Contact, anything that getRecords works on), optional and null have to be different so that setRecords can tell the difference between "clear this property" and "don't touch this property".
* In second-level datatypes (eg Attachment, File), we never need to have a partial type because we only ever get/set an entire object. So it should never be necessary to have a missing property. If we really don't want to specify a value (eg Attachment.width), it should be null.
* In method requests/responses, again, there's no reason to have a missing property when is available. This works for things like getRecords "ids" and "properties", where empty array means "I don't want anything" and null/missing means "I want everything".
* So now we have null everywhere. The only place that optional values makes any sense is in top-level datatypes in get/set/getUpdates. That's consistent.
* And since we have null everywhere, we can now make null and missing mean exactly the same thing, reducing the amount of nulls we have to send over the wire. eg getContacts({}) is the same as getContacts({ ids: null, properties: null, sinceState: null })

So basically, everywhere that something was optional before, its now not optional but must be `null`, but then there's a global rule that "`null`" and "not present" are the same thing.

For a bit more consistency and to make things easier for clients, I've made some method args that were previously required optional/nullable if a sane default exists. Two examples are the `fetchRecords` flag to `getFooUpdates` and the `filter` arg to `getMessageList`.

Similarly, I've made most returned parameters required, for example the various lists returned by `setFoos`. The hope is that it makes things easier for clients by not requiring them to check for a missing value, particularly for lists, where they can just iterate over the empty lists. There's some places I haven't done this, for example, the `notFound` property returned by `getContacts`, where `null` has special meaning. (though maybe that could be changed too).

I did consider that forcing all the return args to be present will increase the amount of data to be transmitted, but I think its ok because its only a very small increase and the major call affected is `setFoos` which isn't performed very often compared to `getFoos` and `getFooUpdates`.

I haven't touched authentication at all because I have no experience with it, though `password` is the only optional field there. I also haven't touched the `Recurrence` object because it makes reference to the "canonical representation" and I'm unsure if the same optional -> `null` change would break something there.