### PR TITLE
Refer to the mayCreateChild mailbox property instead of mayCreateSub

### DIFF
--- a/spec/mailbox.mdwn
+++ b/spec/mailbox.mdwn
@@ -167,7 +167,7 @@ For compatibility with possible future extensions, the server MUST ignore any un
 The properties of the Mailbox object submitted for creation MUST conform to the following conditions:
 
 - The *id* property MUST NOT be present.
-- The *parentId* property MUST be either `null` or be a valid id for a mailbox for which the `mayCreateSub` property is `true`.
+- The *parentId* property MUST be either `null` or be a valid id for a mailbox for which the `mayCreateChild` property is `true`.
 - The *role* property MUST be either `null`, a valid role as listed in the Mailbox object specification, or prefixed by `"x-"`.
 - The *mustBeOnlyMailbox* property MUST NOT be present. This is server dependent and will be set by the server.
 - The *mayXXX* properties MUST NOT be present. Restrictions may only be set by the server for system mailboxes, or when sharing mailboxes with other users (setting sharing is not defined yet in this spec).
@@ -186,7 +186,7 @@ For compatibility with possible future extensions, the server MUST ignore any un
 All properties being updated must be of the correct type, not immutable or server-set-only, and the new value must obey all conditions of the property. In particular, note the following conditions:
 
 - The *name* property MUST be valid UTF-8, between 1 and 256 bytes in size.
-- The *parentId* property MUST be either `null` or be a valid id for *another* mailbox that is **not a descendant** of this mailbox, and for which the `mayCreateSub` property is `true`.
+- The *parentId* property MUST be either `null` or be a valid id for *another* mailbox that is **not a descendant** of this mailbox, and for which the `mayCreateChild` property is `true`.
 - These properties are immutable or may only be set by the server:
   - id
   - role


### PR DESCRIPTION
I assume `mayCreateSub` should be `mayCreateChild` or vice versa. Hope I fixed it the right way around.