### PR TITLE
Localtime not just for recurrences

### DIFF
--- a/spec/apimodel.mdwn
+++ b/spec/apimodel.mdwn
@@ -104,7 +104,7 @@ The JSON datatypes are limited to those found in JavaScript. A `Number` in JavaS
 
 Where the API specifies `Date` as a type, it means a string in [RFC3339](https://tools.ietf.org/html/rfc3339) *date-time* format, with the *time-offset* component always `Z` (i.e. the date-time MUST be in UTC time) and *time-secfrac* always omitted. The "T" and "Z" MUST always be upper-case. For example, `"2014-10-30T14:12:00Z"`.
 
-Where the API specifies `LocalDate` as a type, it means a string in the same format as `Date`, but with the `Z` omitted from the end. This only occurs in relation to calendar event recurrences, due to the need for them to be expanded and interpreted in local time for a particular time zone. The interpretation in absolute time depends upon the time zone for the event, which MAY not be a fixed offset (for example when daylight savings occurs).
+Where the API specifies `LocalDate` as a type, it means a string in the same format as `Date`, but with the `Z` omitted from the end. This only occurs in relation to calendar events. The interpretation in absolute time depends upon the time zone for the event, which MAY not be a fixed offset (for example when daylight savings occurs).
 
 ### Use of `null`
 

--- a/spec/calendarevent.mdwn
+++ b/spec/calendarevent.mdwn
@@ -104,7 +104,7 @@ A **Recurrence** object is a JSON object mapping of a RECUR value type in iCalen
 - **count**: `Number` (optional)
   The COUNT part from iCal. This MUST NOT be included if an *until* property is specified.
 - **until**: `LocalDate` (optional)
-  The UNTIL part from iCal. This MUST NOT be included if a *count* property is specified. Note, as in iCal, this date is presumed to be in the timezone specified in *startTimeZone*. It is not a UTC time.
+  The UNTIL part from iCal. This MUST NOT be included if a *count* property is specified.
 
 An **Alert** Object has the following properties:
 


### PR DESCRIPTION
LocalDate now applies to all datetime properties of calendar events, not just recurrences.