### PR TITLE
fixing some minor typos on the apimodel page

### DIFF
--- a/spec/apimodel.mdwn
+++ b/spec/apimodel.mdwn
@@ -104,11 +104,11 @@ The JSON datatypes are limited to those found in JavaScript. A `Number` in JavaS
 
 Where the API specifies `Date` as a type, it means a string in [RFC3339](https://tools.ietf.org/html/rfc3339) *date-time* format, with the *time-offset* component always `Z` (i.e. the date-time MUST be in UTC time) and *time-secfrac* always omitted. The "T" and "Z" MUST always be upper-case. For example, `"2014-10-30T14:12:00Z"`.
 
-Where the API specifies `LocalDate` as a type, it means a string in the same format as `Date`, but with the `Z` omitted from the end. This only occurs in relation to calendar events. The interpretation in absolute time depends upon the time zone for the event, which MAY not be a fixed offset (for example when daylight savings occurs).
+Where the API specifies `LocalDate` as a type, it means a string in the same format as `Date`, but with the `Z` omitted from the end. This only occurs in relation to calendar events. The interpretation in absolute time depends upon the time zone for the event, which MAY not be a fixed offset (for example when daylight saving time occurs).
 
 ### Use of `null`
 
-Unless otherwise noted, a missing property in a request, response or object MUST be intepreted exactly the same as that property having the value `null` If `null` is not a valid value for that property this would typically cause an error to occur. This rule does not apply to the [top-level datatypes](#data-model-overview), where a missing property usually indicates that the sender wants to leave the existing property value untouched (e.g. in a [`setFoos`](#setfoos) request or a [`getFooUpdates`](#getfooupdates) response.
+Unless otherwise noted, a missing property in a request, response or object MUST be intepreted exactly the same as that property having the value `null`. If `null` is not a valid value for that property this would typically cause an error to occur. This rule does not apply to the [top-level datatypes](#data-model-overview), where a missing property usually indicates that the sender wants to leave the existing property value untouched (e.g. in a [`setFoos`](#setfoos) request or a [`getFooUpdates`](#getfooupdates) response).
 
 ### Unknown arguments and properties
 


### PR DESCRIPTION
- 'daylight saving time' is the correct term
- added a missing period
- added missing closing parenthesis