### PR TITLE
Use blobId instead of file URL in importMessages

### DIFF
--- a/spec/message.mdwn
+++ b/spec/message.mdwn
@@ -361,8 +361,8 @@ The *importMessages* method adds RFC2822 messages to a user's set of messages. T
 
 An **MessageImport** object has the following properties:
 
-- **file**: `String`
-  The URL of the uploaded file (see the file upload section).
+- **blobId**: `String`
+  The id representing the raw RFC2822 message (see the file upload section).
 - **mailboxIds** `String[]`
   The ids of the mailbox(es) to assign this message to.
 - **isUnread**: `Boolean`


### PR DESCRIPTION
I assume this slipped through the cracks when all the upload stuff got changed to blobIds.