### PR TITLE
Description fix for accountNoContacts

### DIFF
--- a/spec/contact.mdwn
+++ b/spec/contact.mdwn
@@ -127,7 +127,7 @@ The following errors may be returned instead of the *contacts* response:
 
 `accountNotFound`: Returned if an *accountId* was explicitly included with the request, but it does not correspond to a valid account.
 
-`accountNoContacts`: Returned if the *accountId* given corresponds to a valid account, but does not contain any contact data.
+`accountNoContacts`: Returned if the *accountId* given corresponds to a valid account, but does not support contacts.
 
 `invalidArguments`: Returned if the request does not include one of the required arguments, or one of the arguments is of the wrong type, or otherwise invalid. A `description` property MAY be present on the response object to help debug with an explanation of what the problem was.
 
@@ -169,7 +169,7 @@ The following errors may be returned instead of the `contactUpdates` response:
 
 `accountNotFound`: Returned if an *accountId* was explicitly included with the request, but it does not correspond to a valid account.
 
-`accountNoContacts`: Returned if the *accountId* given corresponds to a valid account, but does not contain any contacts data.
+`accountNoContacts`: Returned if the *accountId* given corresponds to a valid account, but does not support contacts.
 
 `invalidArguments`: Returned if the request does not include one of the required arguments, or one of the arguments is of the wrong type, or otherwise invalid. A `description` property MAY be present on the response object to help debug with an explanation of what the problem was.
 
@@ -236,7 +236,7 @@ The following errors may be returned instead of the *contactsSet* response:
 
 `accountNotFound`: Returned if an *accountId* was explicitly included with the request, but it does not correspond to a valid account.
 
-`accountNoContacts`: Returned if the *accountId* given corresponds to a valid account, but does not contain any contacts data.
+`accountNoContacts`: Returned if the *accountId* given corresponds to a valid account, but does not support contacts.
 
 `accountReadOnly`: Returned if the account has `isReadOnly == true`.
 

--- a/spec/contactgroup.mdwn
+++ b/spec/contactgroup.mdwn
@@ -33,7 +33,7 @@ The following errors may be returned instead of the *contactGroups* response:
 
 `accountNotFound`: Returned if an *accountId* was explicitly included with the request, but it does not correspond to a valid account.
 
-`accountNoContacts`: Returned if the *accountId* given corresponds to a valid account, but does not contain any contact data.
+`accountNoContacts`: Returned if the *accountId* given corresponds to a valid account, but does not support contacts.
 
 `invalidArguments`: Returned if one of the arguments is of the wrong type, or otherwise invalid. A `description` property MAY be present on the response object to help debug with an explanation of what the problem was.
 
@@ -67,7 +67,7 @@ The following errors may be returned instead of the `contactGroupUpdates` respon
 
 `accountNotFound`: Returned if an *accountId* was explicitly included with the request, but it does not correspond to a valid account.
 
-`accountNoContacts`: Returned if the *accountId* given corresponds to a valid account, but does not contain any contacts data.
+`accountNoContacts`: Returned if the *accountId* given corresponds to a valid account, but does not support contacts.
 
 `invalidArguments`: Returned if the request does not include one of the required arguments, or one of the arguments is of the wrong type, or otherwise invalid. A `description` property MAY be present on the response object to help debug with an explanation of what the problem was.
 

--- a/spec/contactlist.mdwn
+++ b/spec/contactlist.mdwn
@@ -106,6 +106,6 @@ The following errors may be returned instead of the `contactList` response:
 
 `accountNotFound`: Returned if an *accountId* was explicitly included with the request, but it does not correspond to a valid account.
 
-`accountNoContacts`: Returned if the *accountId* given corresponds to a valid account, but does not support storing contact data.
+`accountNoContacts`: Returned if the *accountId* given corresponds to a valid account, but does not support contacts.
 
 `invalidArguments`: Returned if the request does not include one of the required arguments, or one of the arguments is of the wrong type, or otherwise invalid. A `description` property MAY be present on the response object to help debug with an explanation of what the problem was.


### PR DESCRIPTION
The 'accountNoContacts' error is returned when the account does not support contacts, not when there is no data.