### PR TITLE
Server should indicate if vacation is activated

### DIFF
--- a/spec/vacationresponse.mdwn
+++ b/spec/vacationresponse.mdwn
@@ -8,6 +8,8 @@ related settings for an account. It has the following properties:
   vacation response object, and its id is `"singleton"`.
 - **isEnabled** `Boolean`
   Is the vacation response enabled?
+- **isActivated** `Boolean|null`
+  Server set property. It will be ignored in the client request. It will return true if the enabled value is true, and if we are currently in the time range between fromDate and toDate, ie : when eMail replies will be generated based on this vacationReply.
 - **fromDate**: `Date|null`
   If *isEnabled* is `true`, the date/time after which messages that arrive should receive the user's vacation response, in UTC. If `null`, the vacation response is effective immediately.
 - **toDate**: `Date|null`


### PR DESCRIPTION
Nowadays, the JMAP server returns a VacationResponse.

This vacation response comport :
 - an enable field
 - a fromDate
 - a toDate

To know if the vacation is active (ie : response wil be sent to incoming mails) the client needs to verify the date is in the range and the vacation is enabled.

This approch is limited as the client might have some issue with its local time (and thus might make errors on the activate status). Moreover, we concider this operation should belong to the server.

Thus, we propose to add an additional field to the VacationResponse : "isActivated"

Optional, calculated on the server side, ignored on client's SetVacationResponse request, it is true if the vacation is activated, false otherwise.