### PR TITLE
Adding the Message::isForwarded property

### DIFF
--- a/server-guide/jmap-server-guide.mdown
+++ b/server-guide/jmap-server-guide.mdown
@@ -56,7 +56,7 @@ Data sync properties:
   (after stripping fwd/re etc.). This is used for checking whether we need to
   split out a new thread when a message arrives as the subject has changed (see data structure 7).
 - **messages**: `ThreadMessage[]`
-  The list of messages belonging to the thread, sorted with drafts immediately after the message they are in reply to, then by date order.
+  The list of messages belonging to the thread, sorted with drafts immediately after the message they are in reply to or then the message they are fowarding, then by date order.
 
     A **ThreadMessage** has the following properties:
 

--- a/server-guide/jmap-server-guide.mdown
+++ b/server-guide/jmap-server-guide.mdown
@@ -28,6 +28,7 @@ Properties below have the values as specified in the **Message** object in the J
 - **isUnread**: `Boolean` (Mutable)
 - **isFlagged**: `Boolean` (Mutable)
 - **isAnswered**: `Boolean` (Mutable)
+- **isFowarded**: `Boolean` (Mutable)
 - **isDraft**: `Boolean` (Mutable by IMAP)
 - **from**: `Emailer[]|null`
 - **to**:  `Emailer[]|null`

--- a/server-guide/jmap-server-guide.mdown
+++ b/server-guide/jmap-server-guide.mdown
@@ -28,7 +28,7 @@ Properties below have the values as specified in the **Message** object in the J
 - **isUnread**: `Boolean` (Mutable)
 - **isFlagged**: `Boolean` (Mutable)
 - **isAnswered**: `Boolean` (Mutable)
-- **isFowarded**: `Boolean` (Mutable)
+- **isForwarded**: `Boolean` (Mutable)
 - **isDraft**: `Boolean` (Mutable by IMAP)
 - **from**: `Emailer[]|null`
 - **to**:  `Emailer[]|null`
@@ -56,7 +56,7 @@ Data sync properties:
   (after stripping fwd/re etc.). This is used for checking whether we need to
   split out a new thread when a message arrives as the subject has changed (see data structure 7).
 - **messages**: `ThreadMessage[]`
-  The list of messages belonging to the thread, sorted with drafts immediately after the message they are in reply to or then the message they are fowarding, then by date order.
+  The list of messages belonging to the thread, sorted with drafts immediately after the message they are in reply to or they are forwarding, then by date order.
 
     A **ThreadMessage** has the following properties:
 
@@ -158,7 +158,7 @@ A log of modseqs when threads are created/updated/deleted, for faster responses 
 
 ### 7. Refs to Thread
 
-This is solely used to look up the conversation to assign to a message on creation/import/delivery. Maps the RFC5322 message ids found in the the `Message-Id`, `References` and `In-Reply-To` headers of each message received to the thread id assigned to that message.
+This is solely used to look up the conversation to assign to a message on creation/import/delivery. Maps the RFC5322 message ids found in the the `Message-Id`, `References`, `In-Reply-To` and `X-Forwarded-Message-Id` headers of each message received to the thread id assigned to that message.
 
 - **id**: A secure hash of the RFC5322 message id. This may well be the message
   id if you assign message ids as recommended.

--- a/spec/mail/message.mdown
+++ b/spec/mail/message.mdown
@@ -23,6 +23,8 @@ A **Message** object has the following properties:
   Is the message flagged? This corresponds to the `\Flagged` system flag in IMAP.
 - **isAnswered**: `Boolean` (Mutable)
   Has the message been replied to? This corresponds to the `\Answered` system flag in IMAP.
+- **isForwarded**: `Boolean` (Mutable)
+  Has the message been forwarded? This corresponds to the `$Forwarded` user flag in IMAP.
 - **isDraft**: `Boolean` (Mutable by the server only)
   Is the message a draft? This corresponds to the `\Draft` system flag in IMAP.
 - **hasAttachment**: `Boolean`
@@ -260,6 +262,7 @@ The properties of the Message object submitted for creation MUST conform to the 
 - **isUnread**: Optional, defaults to `false`. If included this MUST be `false`.
 - **isFlagged**: Optional, defaults to `false`.
 - **isAnswered**: Optional, defaults to `false`. If included this MUST be `false`.
+- **isForwarded**: Optional, defaults to `false`. If included this MUST be `false`.
 - **isDraft**: Optional, defaults to `true`. If included this MUST be `true`.
 - **hasAttachment**: This property MUST NOT be included. It is set by the server upon creation based on the attachments property.
 - **headers**: Optional. The keys MUST only contain the characters a-z
@@ -298,6 +301,7 @@ Only the following properties may be modified:
 - **isFlagged**
 - **isUnread**
 - **isAnswered**
+- **isForwarded**
 
 Note, a mailbox id may be a *creation id* (see `setFoos` for a description of how this works).
 
@@ -380,6 +384,7 @@ An **MessageImport** object has the following properties:
 - **isUnread**: `Boolean`
 - **isFlagged**: `Boolean`
 - **isAnswered**: `Boolean`
+- **isForwarded**: `Boolean`
 - **isDraft**: `Boolean`
 
 If `isDraft == true`, the mailboxes MUST include the drafts or outbox mailbox. Adding to the outbox will send the message, as described in the *setMessages* section (it will NOT automatically mark any other message as *isAnswered*).
@@ -432,6 +437,8 @@ A **MessageCopy** object has the following properties:
   The *isFlagged* property for the copy.
 - **isAnswered**: `Boolean`
   The *isAnswered* property for the copy.
+- **isForwarded**: `Boolean`
+  The *isForwarded* property for the copy.
 - **isDraft**: `Boolean`
   The *isDraft* property for the copy.
 

--- a/spec/mail/message.mdown
+++ b/spec/mail/message.mdown
@@ -17,6 +17,8 @@ A **Message** object has the following properties:
   The ids of the mailboxes the message is in. A message MUST belong to one or more mailboxes at all times (until it is deleted).
 - **inReplyToMessageId**: `String|null`
   The id of the Message this message is a reply to. This is primarily for drafts, but the server MAY support this for received messages as well by looking up the [@!RFC5322] Message-Id referenced in the `In-Reply-To` header and searching for this message in the user's mail.
+- **forwardingMessageId**: `String|null`
+  The id of the Message this message is forwarding. This is primarily for drafts, but the server MAY support this for received messages as well by looking up the [@!RFC5322] Message-Id referenced in the `In-Reply-To` header and searching for this message in the user's mail.
 - **isUnread**: `Boolean` (Mutable)
   Has the message not yet been read? This corresponds to the **opposite** of the `\Seen` system flag in IMAP.
 - **isFlagged**: `Boolean` (Mutable)
@@ -259,6 +261,8 @@ The properties of the Message object submitted for creation MUST conform to the 
 - **threadId**: This property MUST NOT be included. It is set by the server upon creation.
 - **mailboxIds**: This property MUST be included. The value MUST include the id of either the mailbox with `role == "drafts"` (to save a draft) or the mailbox with `role == "outbox"` (to send the message). If this mailbox does not have `mustBeOnlyMailbox == true`, others may be included too.
 - **inReplyToMessageId**: Optional. If included, the server will look up this message and if found set appropriate `References` and `In-Reply-To` headers. These will override any such headers supplied in the *headers* property. If not found, the creation MUST be rejected with an `inReplyToNotFound` error.
+- **forwardingMessageId**: Optional. If included, the server will look up this message and if found set appropriate `References` and `X-Forwarded-Message-Id` headers. These will override any such headers 
+supplied in the *headers* property. If not found, the creation MUST be rejected with a `forwardingNotFound` error.
 - **isUnread**: Optional, defaults to `false`. If included this MUST be `false`.
 - **isFlagged**: Optional, defaults to `false`.
 - **isAnswered**: Optional, defaults to `false`. If included this MUST be `false`.
@@ -317,7 +321,13 @@ To send a message, either create a new message directly into the mailbox with `r
 
 If the message is accepted, the server SHOULD **asynchronously** schedule the message to be sent **after** this method call is complete (note, this MAY occur before the next method in the same API request or after the whole API request is complete). This means that the `newState` string in the response represents a state where the message is still in the outbox.
 
-When the message is sent, the server MUST delete the message from the **outbox** and SHOULD create a **new** copy of the sent message (with a new id) in the **sent** mailbox, unless the user has indicated another preference. If `inReplyToMessageId` was set, the server SHOULD mark this message as `isAnswered: true` at this point, if found. The server is responsible for either reporting an error (normally a "bounce" email), or ensuring delivery of the message to the next hop.
+When the message is sent, the server MUST delete the message from the **outbox** and SHOULD create a **new** copy of the sent message (with a new id) in the **sent** mailbox, unless the user has indicated another preference. 
+
+If `inReplyToMessageId` was set, the server SHOULD mark this message as `isAnswered: true` at this point, if found.
+
+If `forwardingMessageId` was set, the server SHOULD mark this message as `isForwarded: true` at this point, if found. 
+
+The server is responsible for either reporting an error (normally a "bounce" email), or ensuring delivery of the message to the next hop.
 
 ### Cancelling a send
 

--- a/spec/mail/messagelist.mdown
+++ b/spec/mail/messagelist.mdown
@@ -71,6 +71,8 @@ A **FilterCondition** object has the following properties:
   The `isUnread` property of the message must be identical to the value given to match the condition.
 - **isAnswered**: `Boolean|null`
   The `isAnswered` property of the message must be identical to the value given to match the condition.
+- **isForwarded**: `Boolean|null`
+  The `isForwarded` property of the message must be identical to the value given to match the condition.
 - **isDraft**: `Boolean|null`
   The `isDraft` property of the message must be identical to the value given to match the condition.
 - **hasAttachment**: `Boolean|null`

--- a/spec/mail/thread.mdown
+++ b/spec/mail/thread.mdown
@@ -13,7 +13,7 @@ A **Thread** object has the following properties:
 - **messageIds**: `String[]`
   The ids of the messages in the thread, sorted such that:
 
-    - Any message with `isDraft == true` and an *inReplyToMessageId* property that corresponds to another message in the thread comes immediately after that message in the sort order.
+    - Any message with `isDraft == true` and an *inReplyToMessageId* or *forwardingMessagId* property that corresponds to another message in the thread comes immediately after that message in the sort order.
     - Other than that, everything is sorted in date order (the same as the *date* property on the Message object), oldest first.
 
 ## getThreads


### PR DESCRIPTION
Hello,

At Linagora, we tend to consider **forward** information as important
for the email we care about.

Today, it is not part of the RFC-3501 spec, and many IMAP
implementations handle it with the de-facto standard $Forwarded flag.

This implicit standard is a bad thing, and we truly would like the JMAP
mail protocol to do this right. To be right, it should be explicit.

We then propose this pull request.

It reproduces the behaviour of **answered** feature:

 - Adds a **isForwarded** message property
 - Adds a mechanism for automatically marking messages as forwarded upon
sending emails
 - Clarifies interactions between isForwarded and threads
 - Makes isForwarded searchable

Does this proposal make sense to you?