### PR TITLE
Propose text search in attachments

### DIFF
--- a/spec/mail/messagelist.mdown
+++ b/spec/mail/messagelist.mdown
@@ -76,7 +76,7 @@ A **FilterCondition** object has the following properties:
 - **hasAttachment**: `Boolean|null`
   The `hasAttachment` property of the message must be identical to the value given to match the condition.
 - **text**: `String|null`
-  Looks for the text in the *from*, *to*, *cc*, *bcc*, *subject*, *textBody* or *htmlBody* properties of the message.
+  Looks for the text in messages. The server SHOULD look up text in the *from*, *to*, *cc*, *bcc*, *subject*, *textBody*, *htmlBody* or *attachments* properties of the message. The server MAY extend the search to any additional textual property.
 - **from**: `String|null`
   Looks for the text in the *from* property of the message.
 - **to**: `String|null`

--- a/spec/mail/messagelist.mdown
+++ b/spec/mail/messagelist.mdown
@@ -89,6 +89,8 @@ A **FilterCondition** object has the following properties:
   Looks for the text in the *subject* property of the message.
 - **body**: `String|null`
   Looks for the text in the *textBody* or *htmlBody* property of the message.
+- **attachments**: `String|null`
+  Looks for the text in the attachments of the message. Server MAY handle text extraction when possible for the different kinds of media.
 - **header**: `String[]|null`
   The array MUST contain either one or two elements. The first element is the name of the header to match against. The second (optional) element is the text to look for in the header. If not supplied, the message matches simply if it *has* a header of the given name.
 

--- a/spec/mail/searchsnippet.mdown
+++ b/spec/mail/searchsnippet.mdown
@@ -11,9 +11,9 @@ A **SearchSnippet** object has the following properties:
 - **preview**: `String|null`
   If text from the filter matches the plain-text or HTML body, this is the relevant section of the body (converted to plain text if originally HTML), HTML-escaped, with matching words/phrases wrapped in `<mark></mark>` tags, up to 256 characters long. If it does not match, this is `null`.
 - **attachments**: `String|null`
-  If text from the filter matches the text extracted from an attachment, this is the relevant section of the body (converted to plain text), with matching words/phrases wrapped in `<mark></mark>` tags, up to 256 characters long. If it does not match, this is `null`.
+  If text from the filter matches the text extracted from an attachment, this is the relevant section of the attachment (converted to plain text), with matching words/phrases wrapped in `<mark></mark>` tags, up to 256 characters long. If it does not match, this is `null`.
 
-It is server-defined what is a relevant section of the body for preview. If the server is unable to determine search snippets, it MUST return `null` for both the *subject*, *preview* and *attachment* properties.
+It is server-defined what is a relevant section of the body for preview. If the server is unable to determine search snippets, it MUST return `null` for both the *subject*, *preview* and *attachments* properties.
 
 Note, unlike most data types, a SearchSnippet DOES NOT have a property called `id`.
 

--- a/spec/mail/searchsnippet.mdown
+++ b/spec/mail/searchsnippet.mdown
@@ -10,8 +10,10 @@ A **SearchSnippet** object has the following properties:
   If text from the filter matches the subject, this is the subject of the message HTML-escaped, with matching words/phrases wrapped in `<mark></mark>` tags. If it does not match, this is `null`.
 - **preview**: `String|null`
   If text from the filter matches the plain-text or HTML body, this is the relevant section of the body (converted to plain text if originally HTML), HTML-escaped, with matching words/phrases wrapped in `<mark></mark>` tags, up to 256 characters long. If it does not match, this is `null`.
+- **attachments**: `String|null`
+  If text from the filter matches the text extracted from an attachment, this is the relevant section of the body (converted to plain text), with matching words/phrases wrapped in `<mark></mark>` tags, up to 256 characters long. If it does not match, this is `null`.
 
-It is server-defined what is a relevant section of the body for preview. If the server is unable to determine search snippets, it MUST return `null` for both the *subject* and *preview* properties.
+It is server-defined what is a relevant section of the body for preview. If the server is unable to determine search snippets, it MUST return `null` for both the *subject*, *preview* and *attachment* properties.
 
 Note, unlike most data types, a SearchSnippet DOES NOT have a property called `id`.
 


### PR DESCRIPTION
By the following proposal, I would like to submit a small addition to the specification to allow text search in attachments.

Attachments are the only non-searchable field, and I can hardly see why the specification should be restrictive on this.

You will notice the **may** about text extraction. It allows a default implementation that just index attachments with **text/\*** making a minimal implementation server side working in a question of minutes.