### PR TITLE
Restrict subset of message keyword characters to 0x21–0x7e.

### DIFF
--- a/spec/mail/message.mdown
+++ b/spec/mail/message.mdown
@@ -27,7 +27,7 @@ A **Message** object has the following properties:
 
     The IMAP `\Recent` keyword is not exposed via JMAP. The IMAP `\Deleted` keyword is also not present: IMAP uses a delete+expunge model, which JMAP does not. Any message with the `\Deleted` keyword MUST NOT be visible via JMAP.
 
-    Users may add arbitrary keywords to a message. For compatibility with IMAP, a keyword is a (case-sensitive) string of 1–255 characters in the ASCII subset %x21–%x127 (excludes control chars and space), and MUST NOT include any of these characters: `( ) { ] % * " \`
+    Users may add arbitrary keywords to a message. For compatibility with IMAP, a keyword is a (case-sensitive) string of 1–255 characters in the ASCII subset %x21–%x7e (excludes control chars and space), and MUST NOT include any of these characters: `( ) { ] % * " \`
 
     The [IANA Keyword Registry](https://www.iana.org/assignments/imap-keywords/imap-keywords.xhtml) as established in [@!RFC5788] assigns semantic meaning to some other keywords in common use. New keywords may be established here in the future. In particular, note:
 


### PR DESCRIPTION
The original definition of allowed keyword character range defined it to be 0x21 to 0x127. This very much looks like a mixup between hex and decimal notation?