### PR TITLE
Corrected typo to match RFC : https://tools.ietf.org/html/rfc2822#section-3.6.4

### DIFF
--- a/server-guide/jmap-server-guide.mdown
+++ b/server-guide/jmap-server-guide.mdown
@@ -157,7 +157,7 @@ A log of modseqs when threads are created/updated/deleted, for faster responses 
 
 ### 7. Refs to Thread
 
-This is solely used to look up the conversation to assign to a message on creation/import/delivery. Maps the RFC5322 message ids found in the the `Message-Id`, `References` and `In-Reply-To` headers of each message received to the thread id assigned to that message.
+This is solely used to look up the conversation to assign to a message on creation/import/delivery. Maps the RFC5322 message ids found in the the `Message-ID`, `References` and `In-Reply-To` headers of each message received to the thread id assigned to that message.
 
 - **id**: A secure hash of the RFC5322 message id. This may well be the message
   id if you assign message ids as recommended.


### PR DESCRIPTION
Typo in the server guide