### PR TITLE
Make mailbox name more compatible with IMAP

### DIFF
--- a/spec/mail/mailbox.mdown
+++ b/spec/mail/mailbox.mdown
@@ -9,7 +9,7 @@ A **Mailbox** object has the following properties:
 - **id**: `String` (immutable; server-set)
   The id of the mailbox.
 - **name**: `String`
-  User-visible name for the mailbox, e.g. "Inbox". This may be any UTF-8  string ([@!RFC3629]) of at least 1 character in length and maximum 256 bytes in size. Servers SHOULD forbid sibling Mailboxes with the same name.
+  User-visible name for the mailbox, e.g. "Inbox". This may be any Net-Unicode string ([@!RFC5198]) of at least 1 character in length and maximum 256 bytes in size. Servers SHOULD forbid sibling Mailboxes with the same name. Servers MAY reject names that violate server policy (e.g., names containing slash (/) or control characters).
 - **parentId**: `String|null` (default: `null`)
   The mailbox id for the parent of this mailbox, or `null` if this mailbox is at the top level. Mailboxes form acyclic graphs (forests) directed by the child-to-parent relationship. There MUST NOT be a loop.
 - **role**: `String|null` (default: `null`)


### PR DESCRIPTION
UTF-8 can express the same character with different byte sequences. Normalization form C, most easily referenced in the IETF as Net-Unicode (RFC 5198) eliminates many of these cases. RFC 6855 requires IMAP mailbox names to conform to NFC. Also many IMAP servers apply additional naming policies because of filesystem limitations. Indexed search engines generally normalize to avoid false negatives, but this means results from indexed search engines are normalized, so if you want to match them back to the mailbox name when it's used as a key (unfortunately necessary in IMAP since it doesn't have a mailbox id), you can get false negative results. Best to avoid this by constraining names to a more reasonable scope. Unfortunately MacOS has a tendency to leak non-normalized Unicode because it uses an old filesystem that tends to decompose Unicode. So best to make the spec clear on this point.