### PR TITLE
Fix vacation extension reference

### DIFF
--- a/rfc/src/vacation.mdown
+++ b/rfc/src/vacation.mdown
@@ -32,4 +32,4 @@ This document specifies a data model for fetching and configuring an email vacat
 
 {mainmatter}
 
-{{spec/mail/vacationresponse.mdown}}
+{{spec/vacation/vacationresponse.mdown}}


### PR DESCRIPTION
The reference has been broken when vacation has been moved to an extension.