### PR TITLE
Add Email/set response to MDN/set example

### DIFF
--- a/spec/mdn/mdn.mdown
+++ b/spec/mdn/mdn.mdown
@@ -144,6 +144,18 @@ If the email id matches an existing email without the `$MDNSent` keyword, the se
         }
       }
     }, "0" ],
+    [ "Email/set", {
+      "accountId": "ue150411c",
+      "oldState": "23",
+      "newState": "42",
+      "updated": {
+        "Md45b47b4877521042cec0938": {
+          "keywords": {
+            "$MDNSent": true
+          }
+        }
+      }
+    }, "0" ]]
 
 
 ## Asking for MDN when sending an email


### PR DESCRIPTION
Add response for the implicit `Email/set` call when doing `MDN/set`.