### PR TITLE
Moving Atmail to confirmed list

### DIFF
--- a/software/software.mdown
+++ b/software/software.mdown
@@ -15,6 +15,7 @@
 * **[Cyrus IMAP](https://cyrusimap.org/imap/download/release-notes/3.0/x/3.0.3.html)** (C, BSD-style): A scalable enterprise-grade IMAP, CalDAV and CardDAV server. The 3.0 series is adding JMAP support, instructions to enable it are [here](https://www.cyrusimap.org/dev/imap/developer/jmap.html).
 * **[Apache James](http://james.apache.org/)** (Java, Apache): Apache James, a.k.a. Java Apache Mail Enterprise Server is an open source mail server written entirely in Java. The 3.0 series is adding JMAP support.
 * **[Group-Office](https://github.com/Intermesh/groupoffice)** (PHP): Open source groupware and collaboration platform
+* **[atmail](https://www.atmail.com/blog/jmap-rfc-8620/)
 
 ## Libraries
 
@@ -28,7 +29,6 @@
 ## Planned
 
 * [Dovecot](http://dovecot.org/pipermail/dovecot/2016-November/106262.html)
-* [atmail](https://www.atmail.com/blog/how-does-jmap-make-email-better/)
 
 
 ## Requested


### PR DESCRIPTION
"And second, because as early adopters of JMAP, we’ve invested a lot of time and development cycles into atmail’s JMAP-based product (atmail suite)." Source: https://www.atmail.com/blog/jmap-rfc-8620/

Former interesting URL is findable via this more recent blog post.