### PR TITLE
Switch definition of recurrenceOverrides arguments in CalendarEvent/get

### DIFF
--- a/spec/calendars/event.mdown
+++ b/spec/calendars/event.mdown
@@ -78,9 +78,9 @@ Clients may choose to skip creating the overrides if the old data is not importa
 This is a standard "/get" method as described in [@!RFC8620], Section 5.1, with three extra arguments:
 
 - **recurrenceOverridesBefore**: `UTCDate|null`
-  If given, only recurrence overrides with a recurrence id on or after this date (when translated into UTC) will be returned.
-- **recurrenceOverridesAfter**: `UTCDate|null`
   If given, only recurrence overrides with a recurrence id before this date (when translated into UTC) will be returned.
+- **recurrenceOverridesAfter**: `UTCDate|null`
+  If given, only recurrence overrides with a recurrence id on or after this date (when translated into UTC) will be returned.
 - **reduceParticipants**: `Boolean` (default: false)
   If true, only participants with the "owner" role or corresponding to the user's participant identities will be returned in the "participants" property of the master event and any recurrence overrides. If false, all participants will be returned.
 


### PR DESCRIPTION
The former definition used the semantics of before for after, and the other way round.