### PR TITLE
Fix typo in calendarHasEvent set error definition

### DIFF
--- a/spec/calendars/calendar.mdown
+++ b/spec/calendars/calendar.mdown
@@ -178,5 +178,5 @@ The following extra SetError types are defined:
 
 For "destroy":
 
-- **calendarHasEvent**: The Calendar has at least one CalendarEvent assigned to
+- **calendarHasEvents**: The Calendar has at least one CalendarEvent assigned to
   it, and the "onDestroyRemoveEvents" argument was false.


### PR DESCRIPTION
The set error definition was missing a `s`, but its description in the onDestroyRemoveEvents definition is in plural.