### PR TITLE
Fix typo in calendarHasEvent set error definition

### DIFF
--- a/spec/calendars/calendar.mdown
+++ b/spec/calendars/calendar.mdown
@@ -156,7 +156,7 @@ This is a standard "/set" method as described in [@!RFC8620], Section 5.3 but wi
 - **onDestroyRemoveEvents**: `Boolean` (default: false)
 
   If false, any attempt to destroy a Calendar that still has CalendarEvents
-  in it will be rejected with a `calendarHasEvents` SetError. If
+  in it will be rejected with a `calendarHasEvent` SetError. If
   true, any CalendarEvents that were in the Calendar will be destroyed. This SHOULD NOT send scheduling messages to participants or create CalendarEventNotification objects.
 
 The "role" and "shareWith" properties may only be set by users that have the mayAdmin right. The value is shared across all users, although users without the mayAdmin right cannot see the value.


### PR DESCRIPTION
Now with set error name in singular.