### PR TITLE
Build with fresh Mmark and xml2rfc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,21 @@
-
-MMARK := /Users/neil/Code/Go/src/github.com/miekg/mmark/mmark/mmark -xml2 -page
+# Your mmark binary
+MMARK := mmark
 
 rfc/build/%.xml: rfc/src/%.mdown spec/%/*
 	mkdir -p $(@D)
 	cat $< | $(MMARK) > $@
 
 rfc/build/%.txt: rfc/build/%.xml
-	tclsh ~/xml2rfc-dev/xml2rfc.tcl --text `pwd`/$^ `pwd`/$@
+	xml2rfc --text $<
 
 rfc/build/%.html: rfc/build/%.xml
-	tclsh ~/xml2rfc-dev/xml2rfc.tcl --html `pwd`/$^ `pwd`/$@
+	xml2rfc --html $<
 
 .PHONY: build
 
 build: rfc/build/jmap.txt rfc/build/jmap.html rfc/build/mail.txt rfc/build/mail.html rfc/build/contacts.txt rfc/build/contacts.html rfc/build/calendars.txt rfc/build/calendars.html rfc/build/mdn.txt rfc/build/mdn.html
 
 xml: rfc/build/jmap.xml rfc/build/mail.xml rfc/build/contacts.xml rfc/build/calendars.xml rfc/build/mdn.xml
+
+clean:
+	rm -rf rfc/build

--- a/rfc/src/calendars.mdown
+++ b/rfc/src/calendars.mdown
@@ -10,6 +10,12 @@
 
     date = 2020-06-15T00:00:00Z
 
+    [seriesInfo]
+    name="Internet-Draft"
+    value="draft-ietf-jmap-calendars-03"
+    stream="IETF"
+    status="standard"
+
     [[author]]
     initials="N.M."
     surname="Jenkins"
@@ -56,3 +62,5 @@ This document specifies a data model for synchronizing calendar data with a serv
 {{spec/calendars/eventnotifications.mdown}}
 {{spec/calendars/securityconsiderations.mdown}}
 {{spec/calendars/ianaconsiderations.mdown}}
+
+{backmatter}

--- a/rfc/src/contacts.mdown
+++ b/rfc/src/contacts.mdown
@@ -10,6 +10,12 @@
 
     date = 2019-03-26T00:00:00Z
 
+    [seriesInfo]
+    name="Internet-Draft"
+    value="draft-jenkins-jmapcontacts-00"
+    stream="IETF"
+    status="standard"
+
     [[author]]
     initials="N.M."
     surname="Jenkins"
@@ -37,3 +43,5 @@ This document specifies a data model for synchronising address book data with a 
 {{spec/contacts/contact.mdown}}
 {{spec/contacts/securityconsiderations.mdown}}
 {{spec/contacts/ianaconsiderations.mdown}}
+
+{backmatter}

--- a/rfc/src/jmap.mdown
+++ b/rfc/src/jmap.mdown
@@ -10,6 +10,12 @@
 
     date = 2019-03-18T00:00:00Z
 
+    [seriesInfo]
+    name="RFC"
+    value="8620"
+    stream="IETF"
+    status="standard"
+
     [[author]]
     initials="N.M."
     surname="Jenkins"
@@ -53,3 +59,5 @@ This document specifies a protocol for clients to efficiently query, fetch, and 
 {{spec/jmap/push.mdown}}
 {{spec/jmap/securityconsiderations.mdown}}
 {{spec/jmap/ianaconsiderations.mdown}}
+
+{backmatter}

--- a/rfc/src/mail.mdown
+++ b/rfc/src/mail.mdown
@@ -11,6 +11,12 @@
 
     date = 2019-03-08T00:00:00Z
 
+    [seriesInfo]
+    name="RFC"
+    value="8621"
+    stream="IETF"
+    status="standard"
+
     [[author]]
     initials="N.M."
     surname="Jenkins"
@@ -57,3 +63,5 @@ This document specifies a data model for synchronising email data with a server 
 {{spec/mail/vacationresponse.mdown}}
 {{spec/mail/securityconsiderations.mdown}}
 {{spec/mail/ianaconsiderations.mdown}}
+
+{backmatter}

--- a/rfc/src/mdn.mdown
+++ b/rfc/src/mdn.mdown
@@ -10,6 +10,12 @@
 
     date = 2020-07-27T00:00:00Z
 
+    [seriesInfo]
+    name="Internet-Draft"
+    value="draft-ietf-jmap-mdn-15"
+    stream="IETF"
+    status="standard"
+
     [[author]]
     initials ="R.O."
     surname ="Ouazana"
@@ -33,3 +39,5 @@ This document specifies a data model for handling Message Disposition Notificati
 {mainmatter}
 
 {{spec/mdn/mdn.mdown}}
+
+{backmatter}

--- a/rfc/src/quotas.mdown
+++ b/rfc/src/quotas.mdown
@@ -10,6 +10,12 @@
 
     date = 2019-09-05T00:00:00Z
 
+    [seriesInfo]
+    name="Internet-Draft"
+    value="draft-ietf-jmap-quotas-00"
+    stream="IETF"
+    status="standard"
+
     [[author]]
     initials="R.C."
     surname="Cordier"
@@ -48,3 +54,5 @@ This document specifies a data model for handling quotas on mailboxes with a ser
 {mainmatter}
 
 {{spec/quotas/quotas.mdown}}
+
+{backmatter}


### PR DESCRIPTION
Hey there JMAP maintainers! Without this PR I was unable to build the project on my machine with xml2rfc 3.2.1 and Mmark 2.2.9. I am not very confident about what I am commiting here, since this is the first time that I am playing around with these two tools :P . It still throws a bunch of warnings, but it looks fine to me?

The `[seriesInfo]` item is similar to what I saw in https://github.com/brong/draft-gondwana-jmap-blob .

I assume that the reason it did not work on my system is that you are using older versions of xml2rfc and Mmark which have a different command-line syntax. Is that possible?