### PR TITLE
Add www to the Cyrus IMAP link

### DIFF
--- a/software/software.mdown
+++ b/software/software.mdown
@@ -12,7 +12,7 @@
 ## Servers
 
 * **[JMAP Proxy](https://github.com/jmapio/jmap-perl)** (Perl, MIT): a complete JMAP server implementation that uses any IMAP, CalDAV and CardDAV store as a backend. Also available as a hosted service at [proxy.jmap.io](https://proxy.jmap.io).
-* **[Cyrus IMAP](https://cyrusimap.org/imap/download/release-notes/3.0/x/3.0.3.html)** (C, BSD-style): A scalable enterprise-grade IMAP, CalDAV and CardDAV server. The 3.0 series is adding JMAP support, instructions to enable it are [here](https://www.cyrusimap.org/dev/imap/developer/jmap.html).
+* **[Cyrus IMAP](https://www.cyrusimap.org/imap/download/release-notes/3.0/x/3.0.3.html)** (C, BSD-style): A scalable enterprise-grade IMAP, CalDAV and CardDAV server. The 3.0 series is adding JMAP support, instructions to enable it are [here](https://www.cyrusimap.org/dev/imap/developer/jmap.html).
 * **[Apache James](http://james.apache.org/)** (Java, Apache): Apache James, a.k.a. Java Apache Mail Enterprise Server is an open source mail server written entirely in Java. The 3.0 series is adding JMAP support.
 * **[Group-Office](https://github.com/Intermesh/groupoffice)** (PHP): Open source groupware and collaboration platform
 * **[atmail](https://www.atmail.com/blog/jmap-rfc-8620/)


### PR DESCRIPTION
https://cyrusimap.org/ (without the `www`s) serves with an invalid certificate (the generic one for github pages) and hence doesn't work properly.

Also, opening http://cyrusimap.org/ redirects to https://www.cyrusimap.org/ so it is just better to link to https://www.cyrusimap.org/ directly.