### PR TITLE
Fix atmail mention formatting

### DIFF
--- a/software/software.mdown
+++ b/software/software.mdown
@@ -15,7 +15,7 @@
 * **[Cyrus IMAP](https://www.cyrusimap.org/imap/download/release-notes/3.0/x/3.0.3.html)** (C, BSD-style): A scalable enterprise-grade IMAP, CalDAV and CardDAV server. The 3.0 series is adding JMAP support, instructions to enable it are [here](https://www.cyrusimap.org/dev/imap/developer/jmap.html).
 * **[Apache James](http://james.apache.org/)** (Java, Apache): Apache James, a.k.a. Java Apache Mail Enterprise Server is an open source mail server written entirely in Java. The 3.0 series is adding JMAP support.
 * **[Group-Office](https://github.com/Intermesh/groupoffice)** (PHP): Open source groupware and collaboration platform
-* **[atmail](https://www.atmail.com/blog/jmap-rfc-8620/)
+* **[atmail](https://www.atmail.com/blog/jmap-rfc-8620/)** (golang, proprietary)
 
 ## Libraries
 


### PR DESCRIPTION
seems to be golang based on https://www.atmail.com/on-premises-email/