### PR TITLE
Add initial version of JMAP for tasks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,9 @@ rfc/build/%.html: rfc/build/%.xml
 
 .PHONY: build
 
-build: rfc/build/jmap.txt rfc/build/jmap.html rfc/build/mail.txt rfc/build/mail.html rfc/build/contacts.txt rfc/build/contacts.html rfc/build/calendars.txt rfc/build/calendars.html rfc/build/mdn.txt rfc/build/mdn.html
+build: rfc/build/jmap.txt rfc/build/jmap.html rfc/build/mail.txt rfc/build/mail.html rfc/build/contacts.txt rfc/build/contacts.html rfc/build/calendars.txt rfc/build/calendars.html rfc/build/mdn.txt rfc/build/mdn.html rfc/build/tasks.txt rfc/build/tasks.html
 
-xml: rfc/build/jmap.xml rfc/build/mail.xml rfc/build/contacts.xml rfc/build/calendars.xml rfc/build/mdn.xml rfc/build/sharing.xml
+xml: rfc/build/jmap.xml rfc/build/mail.xml rfc/build/contacts.xml rfc/build/calendars.xml rfc/build/mdn.xml rfc/build/sharing.xml rfc/build/tasks.xml
 
 clean:
 	rm -rf rfc/build

--- a/rfc/src/tasks.mdown
+++ b/rfc/src/tasks.mdown
@@ -1,0 +1,65 @@
+%%%
+    title = "JMAP for Tasks"
+    abbrev = "JMAP Tasks"
+    category = "std"
+    docName = "draft-baum-jmap-tasks-00"
+    ipr = "trust200902"
+    area = "Applications"
+    workgroup = "JMAP"
+    keyword = ["JMAP", "JSON", "tasks"]
+
+    date = 2021-01-29T00:00:00Z
+
+    [seriesInfo]
+    name="Internet-Draft"
+    value="draft-baum-jmap-tasks-00"
+    stream="IETF"
+    status="standard"
+
+    [[author]]
+    initials="J.M."
+    surname="Baum"
+    fullname="Joris Baum"
+    role="editor"
+    organization = "audriga"
+        [author.address]
+        email = "joris@audriga.com"
+        uri = "https://www.audriga.com"
+        [author.address.postal]
+            street = "Durlacher Allee 47"
+            city = "Karlsruhe "
+            code = "76131"
+            country = "Germany"
+
+    [[author]]
+    initials="H.J."
+    surname="Happel"
+    fullname="Hans-Joerg"
+    role="editor"
+    organization = "audriga"
+        [author.address]
+        email = "hans-joerg@audriga.com"
+        uri = "https://www.audriga.com"
+        [author.address.postal]
+            street = "Durlacher Allee 47"
+            city = "Karlsruhe "
+            code = "76131"
+            country = "Germany"
+%%%
+
+.# Abstract
+
+This document specifies a data model for synchronizing task data with a server using JMAP.
+
+{mainmatter}
+
+{{spec/tasks/intro.mdown}}
+{{spec/tasks/principal.mdown}}
+{{spec/tasks/assigneeidentity.mdown}}
+{{spec/tasks/list.mdown}}
+{{spec/tasks/task.mdown}}
+{{spec/tasks/tasknotifications.mdown}}
+{{spec/tasks/securityconsiderations.mdown}}
+{{spec/tasks/ianaconsiderations.mdown}}
+
+{backmatter}

--- a/spec/tasks/assigneeidentity.mdown
+++ b/spec/tasks/assigneeidentity.mdown
@@ -1,0 +1,31 @@
+# Assignee Identities
+
+An AssigneeIdentity stores information about a URI that represents the user within that account in an event's assignees. It has the following properties:
+
+- **id**: `Id` (immutable; server-set)
+  The id of the AssigneeIdentity.
+- **name**: `String` (default: "")
+  The display name of the assignee to use when adding this assignee to a task, e.g. "Jane Bloggs".
+- **sendTo**: `String[String]`
+   Represents methods by which the participant may receive invitations and updates to an event.
+
+     The keys in the property value are the available methods and MUST only contain ASCII alphanumeric characters (A-Za-z0-9). The value is a URI for the method specified in the key.
+
+An assignee in an task corresponds to an AssigneeIdentity if any of the method/uri pairs in the sendTo property of the participant are identical to a method/uri pair in the sendTo property of the identity.
+
+The following JMAP methods are supported.
+
+## AssigneeIdentity/get
+
+This is a standard "/get" method as described in [@!RFC8620], Section 5.1. The *ids* argument may be `null` to fetch all at once.
+
+## AssigneeIdentity/changes
+
+This is a standard "/changes" method as described in [@!RFC8620], Section 5.2.
+
+## AssigneeIdentity/set
+
+This is a standard "/set" method as described in [@!RFC8620], Section 5.3. The server MAY restrict the uri values the user may claim, for example only allowing `mailto:` URIs with email addresses that belong to the user. A standard `forbidden` error is returned to reject non-permissible changes.
+
+
+

--- a/spec/tasks/ianaconsiderations.mdown
+++ b/spec/tasks/ianaconsiderations.mdown
@@ -1,0 +1,21 @@
+# IANA Considerations
+
+## JMAP Capability Registration for "tasks"
+
+TODO Actually register
+
+IANA will register the "tasks" JMAP Capability as follows:
+
+Capability Name: `urn:ietf:params:jmap:tasks`
+
+Specification document: this document
+
+Intended use: common
+
+Change Controller: IETF
+
+Security and privacy considerations: this document, Section XXX
+
+## JSCalendar Property Registrations
+
+All IANA registrations for JSTask are described in JMAP for Calendars [@!I-D.ietf-jmap-calendars].

--- a/spec/tasks/intro.mdown
+++ b/spec/tasks/intro.mdown
@@ -1,0 +1,56 @@
+# Introduction
+
+JMAP ([@!RFC8620] – JSON Meta Application Protocol) is a generic protocol for synchronizing data, such as mail, calendars or contacts, between a client and a server. It is optimized for mobile and web environments, and aims to provide a consistent interface to different data types.
+
+JMAP for Calendars ([@!I-D.ietf-jmap-calendars]) defines a data model for synchronizing calendar data between a client and a server using JMAP. The data model is designed to allow a server to provide consistent access to the same data via CalDAV [@?RFC4791] as well as JMAP.
+
+While CalDAV defines access to tasks, JMAP for Calendars does not. This specification fills this gap and defines a data model for synchronizing task data between a client and a server using JMAP. It is built upon JMAP for Calendars and reuses most of its definitions. For better readability this document only outlines differences between this specification and JMAP for Calendars. If not stated otherwise, the same specifics that apply to Calendar, CalendarEvent and CalendarEventNotification objects as defined in the aforemetioned specification also apply to similar data types introduced in this specification.
+
+## Notational Conventions
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in BCP 14 [@!RFC2119] [@!RFC8174] when, and only when, they appear in all capitals, as shown here.
+
+Type signatures, examples, and property descriptions in this document follow the conventions established in Section 1.1 of [@!RFC8620].  Data types defined in the core specification are also used in this document.
+
+## Terminology
+
+The same terminology is used in this document as in the core JMAP specification, see [@!RFC8620], Section 1.6.
+
+The terms ParticipantIdentity, TaskList, Task and TaskNotification are used to refer to the data types defined in this document and instances of those data types.
+
+## Data Model Overview
+
+Similar to JMAP for Calendar, an Account (see [@!RFC8620], Section 1.6.2) contains zero or more TaskList objects, which is a named collection of Tasks belonging to a Principal (see [@!I-D.jenkins-jmap-sharing] Section XXX). Task lists can also provide defaults, such as alerts and a color to apply to tasks in the calendar. Clients commonly let users toggle visibility of tasks belonging to a particular task list on/off. Servers may allow a task to belong to multiple TaskLists within an account.
+
+A Task is a representation of a single task or recurring series of Tasks in JSTask [@!I-D.ietf-calext-jscalendar] format. Recurrence rules and alerts as defined in JMAP for Calendars (see [@!I-D.ietf-jmap-calendars] Section XXX) apply.
+
+Just like the CalendarEventNotification objects (see [@!I-D.ietf-jmap-calendars] Section XXX), TaskNotification objects keep track of the history of changes made to a task by other users. Similarly, the ShareNotification type (see [@!I-D.jenkins-jmap-sharing] Section XXX) notifies the user when their access to another user's calendar is granted or revoked.
+
+## Addition to the Capabilities Object
+
+The capabilities object is returned as part of the JMAP Session object; see [@!RFC8620], Section 2. This document defines one additional capability URI.
+
+### urn:ietf:params:jmap:tasks
+
+This represents support for the TaskList, Task and TaskNotification data types and associated API methods. The value of this property in the JMAP Session capabilities property is an empty object.
+
+The value of this property in an account’s accountCapabilities property is an object that MUST contain the following information on server capabilities and permissions for that account:
+
+- **shareesActAs**: `String`
+  This MUST be one of:
+
+    - `self` - sharees act as themselves when using tasks in this account.
+    - `secretary`- sharees act as the principal to which this account belongs.
+
+- **maxTaskListsPerTask**: `UnsignedInt|null`
+  The maximum number of TaskLists (see Section XXX) that can be can assigned to a single Task object (see Section XXX). This MUST be an integer >= 1, or null for no limit (or rather, the limit is always the number of TaskLists in the account).
+- **minDateTime**: `LocalDate`
+  The earliest date-time the server is willing to accept for any date stored in a Task.
+- **maxDateTime**: `LocalDate`
+  The latest date-time the server is willing to accept for any date stored in a Task.
+- **maxExpandedQueryDuration**: `Duration`
+  The maximum duration the user may query over when asking the server to expand recurrences.
+- **maxAssigneesPerTask**: `Number|null`
+  The maximum number of assignees a single task may have, or null for no limit.
+- **mayCreateTaskList**: `Boolean`
+  If true, the user may create a task list in this account.

--- a/spec/tasks/list.mdown
+++ b/spec/tasks/list.mdown
@@ -1,0 +1,75 @@
+# TaskLists
+
+A TaskList is a named collection of tasks. All tasks are associated with at least one TaskList.
+
+A **TaskList** object has the following properties:
+
+- **id**: `Id` (immutable; server-set)
+  The id of the task list.
+- **role**: `String|null` (default: null)
+  Denotes the task list has a special purpose. This MUST be one of the following:
+
+    - `inbox`: This is the principal's default task list;
+    - `trash`: This task list holds messages the user has discarded;
+
+- **name**: `String`
+  The user-visible name of the task list. This may be any UTF-8 string of at least 1 character in length and maximum 255 octets in size.
+- **description**: `String|null` (default: null)
+  An optional longer-form description of the task list, to provide context in shared environments where users need more than just the name.
+- **color**: `String|null` (default: null)
+  A color to be used when displaying events associated with the task list.
+
+    If not null, the value MUST be a case-insensitive color name taken from the set of names defined in Section 4.3 of CSS Color Module Level 3 [COLORS](https://www.w3.org/TR/css-color-3/), or an RGB value in hexadecimal notation, as defined in Section 4.2.1 of CSS Color Module Level 3.
+
+    The color SHOULD have sufficient contrast to be used as text on a white background.
+
+- **sortOrder**: `UnsignedInt` (default: 0)
+  Defines the sort order of task lists when presented in the client's UI, so it
+  is consistent between devices. The number MUST be an integer in the range
+  0 <= sortOrder < 2^31.
+
+    A task list with a lower order should be displayed before a list with
+    a higher order in any list of task lists in the client's UI. Task lists with equal order SHOULD be sorted in alphabetical order by name. The sorting should take into account locale-specific character order convention.
+
+- **isSubscribed**: `Boolean`
+  Has the user indicated they wish to see this task list in their client? This SHOULD default to false for task lists in shared accounts the user has access to and true for any new task list created by the user themself.
+
+    If false, the task list should only be displayed when the user explicitly
+    requests it or to offer it for the user to subscribe to.
+
+- **isVisible**: `Boolean` (default: true)
+  Should the task list's events be displayed to the user at the moment? Clients MUST ignore this property if isSubscribed is false. If an event is in multiple task lists, it should be displayed if isVisible is true for any of those task lists.
+
+- **defaultAlertsWithTime**: `Id[Alert]|null` (default: null)
+  A map of alert ids to Alert objects (see [@!I-D.ietf-calext-jscalendar], Section 4.5.2) to apply for events where "showWithoutTime" is false and "useDefaultAlerts" is true. Ids MUST be unique across all default alerts in the account, including those in other task lists; a UUID is recommended.
+- **defaultAlertsWithoutTime**: `Id[Alert]|null` (default: null)
+  A map of alert ids to Alert objects (see [@!I-D.ietf-calext-jscalendar], Section 4.5.2) to apply for events where "showWithoutTime" is true and "useDefaultAlerts" is true. Ids MUST be unique across all default alerts in the account, including those in other task lists; a UUID is recommended.
+- **timeZone**: `String|null` (default: null)
+  The time zone to use for events without a time zone when the server needs to resolve them into absolute time, e.g., for alerts or availability calculation. The value MUST be a time zone id from the IANA Time Zone Database [TZDB](https://www.iana.org/time-zones). If `null`, the timeZone of the account's associated Principal will be used. Clients SHOULD use this as the default for new events in this task list if set.
+- **shareWith**: `Id[CalendarRights]|null` (default: null)
+  A map of Principal id to rights for principals this calendar is shared with. The principal to which this task list belongs MUST NOT be in this set. This is null if the user requesting the object does not have the mayAdmin right, or if the task list  is not shared with anyone. May be modified only if the user has the mayAdmin right. The account id for the principals may be found in the `urn:ietf:params:jmap:principals:owner` capability of the Account to which the calendar belongs.
+
+The user is an **owner** for a task if the Task object has an "assignee" property, and one of the Participant objects both:
+
+1. Has the "chair" role.
+1. Corresponds to one of the user's AssigneeIdentity objects in the account.
+  
+A task has no owner if its assignee property is null or omitted.
+
+TODO currently disregarding `myRights`
+
+## TaskList/get
+
+This is a standard "/get" method as described in [@!RFC8620], Section 5.1. The *ids* argument may be `null` to fetch all at once.
+
+TODO add part about rights properties.
+
+## TaskList/changes
+
+This is a standard "/changes" method as described in [@!RFC8620], Section 5.2.
+
+## TaskList/set
+
+This is the "Calendar/set" method as described in [@!I-D.ietf-jmap-calendars], Section XXX.
+
+TODO copy+paste from "Calendar/set" and replace `onDestroyRemoveEvents` by `onDestroyRemoveTasks` (and `calendarHasEvent`).

--- a/spec/tasks/principal.mdown
+++ b/spec/tasks/principal.mdown
@@ -1,0 +1,15 @@
+# Principals
+
+For systems that also support JMAP Sharing [RFC XXX], the tasks capability is used to indicate that this principal may be used with tasks.
+
+## Principal Capability urn:ietf:params:jmap:tasks
+
+A "urn:ietf:params:jmap:tasks" property is added to the Principal "capabilities" object, the value of which is an object with the following properties:
+
+- **accountId**: `Id|null`
+  Id of Account with the `urn:ietf:params:jmap:tasks` capability that
+  contains the task data for this principal, or null if none (e.g. the Principal is a group just used for permissions management), or the user does not have access to any data in the account.
+- **account**: `Account|null`
+  The JMAP Account object corresponding to the accountId, null if none.
+- **sendTo**: `String[String]|null`
+  If this principal may be added as a participant to an event, this is the map of methods for adding it, in the same format as Participant#sendTo in JSTask (see [@!I-D.ietf-calext-jscalendar], Section 4.4.5).

--- a/spec/tasks/securityconsiderations.mdown
+++ b/spec/tasks/securityconsiderations.mdown
@@ -1,0 +1,3 @@
+# Security Considerations
+
+All security considerations of JMAP for Calendars [@!I-D.ietf-jmap-calendars] apply to this specification.

--- a/spec/tasks/task.mdown
+++ b/spec/tasks/task.mdown
@@ -1,0 +1,96 @@
+# Tasks
+
+A **Task** object contains information about a task, or recurring series of tasks. It is a JSTask object, as defined in [@!I-D.ietf-calext-jscalendar], with the following additional properties:
+
+- **id**: `Id`
+  The id of the Task. This property is immutable. The id uniquely identifies a JSTask with a particular "uid" and "recurrenceId" within a particular account.
+
+- **taskListIds**: `Id[Boolean]`
+  The set of TaskList ids this task belongs to. An task MUST belong to one or more TaskLists at all times (until it is destroyed). The set is represented as an object, with each key being a *TaskList id*. The value for each key in the object MUST be `true`.
+
+- **isDraft**: `Boolean`
+  If true, this task is to be considered a draft. The server will not send any push notifications for alerts. This may only be set to true upon creation. Once set to false, the value cannot be updated to true. This property MUST NOT appear in "recurrenceOverrides".
+
+- **utcStart**: `UTCDate`
+  For simple clients that do not or cannot implement time zone support. Clients should only use this if also asking the server to expand recurrences, as you cannot accurately expand a recurrence without the original time zone.
+
+    This property is calculated at fetch time by the server. Time zones are political and they can and do change at any time. Fetching exactly the same property again may return a different results if the time zone data has been updated on the server. Time zone data changes are not considered "updates" to the task.
+
+    If set, server will convert to the task's current time zone using its current time zone data and store the local time.
+
+    This is not included by default and must be requested explicitly.
+
+    Floating tasks (tasks without a time zone) will be interpreted as per the time zone given as a Task/get argument.
+
+    Note that it is not possible to accurately calculate the expansion of recurrence rules or recurrence overrides with the utcStart property rather than the local start time. Even simple recurrences such as "repeat weekly" may cross a daylight-savings boundary and end up at a different UTC time. Clients that wish to use "utcStart" are RECOMMENDED to request the server expand recurrences (see Section XXX).
+
+- **utcEnd**: `UTCDate`
+  The server calculates the end time in UTC from the start/timeZone/duration properties of the task. This is not included by default and must be requested explicitly. Like utcStart, this is calculated at fetch time if requested and may change due to time zone data changes. Floating tasks will be interpreted as per the time zone given as a Task/get argument.
+
+## Additional JSCalendar properties
+
+This document defines four new JSCalendar properties.
+
+### mayInviteSelf
+
+Type: `Boolean` (default: false)
+
+If `true`, any user that has access to the event may add themselves to it as a participant with the "attendee" role. This property MUST NOT be altered in the recurrenceOverrides; it may only be set on the master object.
+
+### mayInviteOthers
+
+Type: `Boolean` (default: false)
+
+If `true`, any current participant with the "attendee" role may add new participants with the "attendee" role to the event. This property MUST NOT be altered in the recurrenceOverrides; it may only be set on the master object.
+
+### hideAttendees
+
+Type: `Boolean` (default: false)
+
+If `true`, only the owners of the event may see the full set of participants. Other sharees of the event may only see the owners and themselves. This property MUST NOT be altered in the recurrenceOverrides; it may only be set on the master object.
+
+### relatedTo 
+
+Type: `Id[String]|null` (default: null)
+
+A map of task ids to relations. Relation SHOULD be one of:
+    - `blockedBy`: Blocked by task with id.
+    - `clonedBy`: Task with id was cloned from this issue.
+    - `duplicatedBy`: Task with id is a duplicate of this issue.
+    - `causedBy`: Task with id was the cause for this task.
+    - `relatesTo`: Task with id is related.
+    - `childOf`: Task with id is parent.
+
+## Properties similar in JMAP for Calendar
+
+Attachments, per-user properties, recurrences and updates to recurrences are described in [@!I-D.ietf-jmap-calendars], Section XXX.
+
+## Task/get
+
+This is the "CalendarEvent/get" method as described in [@!I-D.ietf-jmap-calendars], Section XXX.
+
+TODO redefine this here. Similar to "TaskList/get" we only need to replace a few definitions. For example, replace `reduceParticipants` with `reduceAssignees`. Copy+Paste most of the stuff.
+
+## Task/changes
+
+This is a standard "/changes" method as described in [@!RFC8620], Section 5.2.
+
+## Task/set
+
+This is the "CalendarEvent/set" method as described in [@!I-D.ietf-jmap-calendars], Section XXX.
+
+TODO copy+paste most stuff from "CalendarEvent/set". It should be fine to just reference patching.
+
+## Task/copy
+
+This is a standard "/copy" method as described in [@!RFC8620], Section 5.4.
+
+## Task/query
+
+This is the "CalendarEvent/query" method as described in [@!I-D.ietf-jmap-calendars], Section XXX.
+
+TODO copy+paste most stuff from "CalendarEvent/query". Mainly filtering should be different.
+
+## Task/queryChanges
+
+This is a standard "/queryChanges" method as described in [@!RFC8620], Section 5.6.

--- a/spec/tasks/tasknotifications.mdown
+++ b/spec/tasks/tasknotifications.mdown
@@ -1,0 +1,82 @@
+# Task Notifications
+
+The TaskNotification data type records changes made by external entities to tasks in calendars the user is subscribed to. Notifications are stored in the same Account as the Task that was changed.
+
+This is the same specification as the CalendarEventNotification object from [@!I-D.ietf-jmap-calendars], Section XXX. Only the object properties differ slightly and are therefore fully described in this document.
+
+## Object Properties
+
+The **TaskNotification** object has the following properties:
+
+- **id**: `String`
+  The id of the TaskNotification.
+- **created**: `UTCDate`
+  The time this notification was created.
+- **changedBy**: `Person`
+  Who made the change.
+  - **name**: `String`
+    The name of the person who made the change.
+  - **email**: `String`
+    The email of the person who made the change, or null if no email is available.
+  - **principalId**: `String|null`
+    The id of the principal corresponding to the person who made the change, if any. This will be null if the change was due to receving an iTIP message.
+- **comment**: `String|null`
+  Comment sent along with the change by the user that made it. (e.g. COMMENT
+  property in an iTIP message).
+- **type**: `String`
+  This MUST be one of
+  - created
+  - updated
+  - destroyed
+- **TaskId**: `String`
+  The id of the Task that this notification is about.
+- **isDraft**: `Boolean` (created/updated only)
+  Is this event a draft?
+- **event**: `JSTask`
+  The data before the change (if updated or destroyed), or the data
+  after creation (if created).
+- **eventPatch**: `PatchObject` (updated only)
+  A patch encoding the change between the data in the event property, and the
+  data after the update.
+
+To reduce data, if the change only affects a single instance of a recurring event, the server MAY set the event and eventPatch properties for the instance; the calendarEventId MUST still be for the master event.
+
+## TaskNotification/get
+
+This is a standard "/get" method as described in [@!RFC8620], Section 5.1.
+
+## TaskNotification/changes
+
+This is a standard "/changes" method as described in [@!RFC8620], Section 5.2.
+
+## TaskNotification/set
+
+This is a standard "/changes" method as described in [@!RFC8620], Section 5.3.
+
+Only destroy is supported; any attempt to create/update MUST be rejected with a
+`forbidden` SetError.
+
+## TaskNotification/query
+
+This is a standard "/query" method as described in [@!RFC8620], Section 5.5.
+
+### Filtering
+
+A **FilterCondition** object has the following properties:
+
+- **after**: `UTCDate|null`
+  The creation date must be on or after this date to match the condition.
+- **before**: `UTCDate|null`
+  The creation date must be before this date to match the condition.
+- **type**: `String`
+  The type property must be the same to match the condition.
+- **taskIds**: `Id[]|null`
+  A list of task ids. The taskId property of the notification must be in this list to match the condition.
+
+### Sorting
+
+The "created" property MUST be supported for sorting.
+
+## TaskNotification/queryChanges
+
+This is a standard "/queryChanges" method as described in [@!RFC8620], Section 5.6.


### PR DESCRIPTION
Provides an initial version of JMAP for Tasks.

I tried to stay as close as possible to JMAP for Calendars as possible only leaving out scheduling stuff (and rights for now). I mainly added task relations compared to Calendar.

Definitely unfinished is:
* Properties related to rights
* Some methods of JMAP for Calendar deviate quite a lot from the typical JMAP methods. However, JMAP for Tasks will probably not deviate from JMAP for Calendar on most occasions (except for naming). I have not copy-pasted all those paragraphs, yet.