### PR TITLE
Add jmapc to libraries list

### DIFF
--- a/software/software.mdown
+++ b/software/software.mdown
@@ -28,6 +28,7 @@
 * **[Java JMAP Library](https://github.com/iNPUTmice/jmap)** (Java 7, Apache): a low level jmap-client library as well as a higher level jmap-mua library.
 * **[melib](https://meli.delivery)** (Rust): mail client library used in *meli* (GPLv3)
 * **[jmap-rs](https://gitlab.com/jmap-rs/jmap-rs)** (Rust; in development): Rust client (and maybe server) library for JMAP
+* **[jmapc](https://pypi.org/project/jmapc/)** (Python; [partially implemented](https://github.com/smkent/jmapc)): Python 3 client library for JMAP mail
 
 
 ## Planned


### PR DESCRIPTION
I started jmapc as a personal project, and have implemented enough to send and receive email. I've published it on pypi. I'm personally using it to [automatically reply to emails](https://github.com/smkent/waffles) from recruiters.