### PR TITLE
Survey and IETF 112 Changes

### DIFF
--- a/rfc/src/tasks.mdown
+++ b/rfc/src/tasks.mdown
@@ -2,17 +2,17 @@
     title = "JMAP for Tasks"
     abbrev = "JMAP Tasks"
     category = "std"
-    docName = "draft-baum-jmap-tasks-00"
+    docName = "draft-ietf-jmap-tasks-03"
     ipr = "trust200902"
     area = "Applications"
     workgroup = "JMAP"
     keyword = ["JMAP", "JSON", "tasks"]
 
-    date = 2021-10-25T00:00:00Z
+    date = 2022-03-07T00:00:00Z
 
     [seriesInfo]
     name="Internet-Draft"
-    value="draft-ietf-jmap-tasks-02"
+    value="draft-ietf-jmap-tasks-03"
     stream="IETF"
     status="standard"
 

--- a/spec/tasks/intro.mdown
+++ b/spec/tasks/intro.mdown
@@ -20,7 +20,7 @@ The terms ParticipantIdentity, TaskList, Task and TaskNotification are used to r
 
 ## Data Model Overview
 
-Similar to JMAP for Calendar, an Account (see [@!RFC8620], Section 1.6.2) contains zero or more TaskList objects, which is a named collection of Tasks belonging to a Principal (see [@!I-D.ietf-jmap-sharing] Section XXX). Task lists can also provide defaults, such as alerts and a color to apply to tasks in the calendar. Clients commonly let users toggle visibility of tasks belonging to a particular task list on/off. Servers may allow a task to belong to multiple TaskLists within an account.
+Similar to JMAP for Calendar, an Account (see [@!RFC8620], Section 1.6.2) contains zero or more TaskList objects, which is a named collection of Tasks belonging to a Principal (see [@!I-D.ietf-jmap-sharing] Section XXX). Task lists can also provide defaults, such as alerts and a color to apply to tasks in the calendar. Clients commonly let users toggle visibility of tasks belonging to a particular task list on/off.
 
 A Task is a representation of a single task or recurring series of Tasks in JSTask [@!I-D.ietf-calext-jscalendar] format. Recurrence rules and alerts as defined in JMAP for Calendars (see [@!I-D.ietf-jmap-calendars] Section XXX) apply.
 

--- a/spec/tasks/task.mdown
+++ b/spec/tasks/task.mdown
@@ -34,6 +34,9 @@ A **Task** object contains information about a task, or recurring series of task
     A task with a lower order should be displayed before a task with
     a higher order in any list of tasks in the client's UI. Tasks with equal order SHOULD be sorted in alphabetical order by name. The sorting should take into account locale-specific character order convention.
 
+- **source**: `String|null` (default: null)
+  The source of the task like "Web app", "Mobile client" or "Email".
+
 ## Additional JSCalendar properties
 
 This document defines four new JSCalendar properties and extends one properties with new values.

--- a/spec/tasks/task.mdown
+++ b/spec/tasks/task.mdown
@@ -1,5 +1,4 @@
 # Tasks
-
 A **Task** object contains information about a task, or recurring series of tasks. It is a JSTask object, as defined in [@!I-D.ietf-calext-jscalendar], with the following additional properties:
 
 - **id**: `Id`
@@ -37,7 +36,7 @@ A **Task** object contains information about a task, or recurring series of task
 
 ## Additional JSCalendar properties
 
-This document defines four new JSCalendar properties.
+This document defines four new JSCalendar properties and extends one properties with new values.
 
 ### mayInviteSelf
 
@@ -69,6 +68,26 @@ A map of task ids to relations. Relation SHOULD be one of:
 - `causedBy`: Task with id was the cause for this task.
 - `relatesTo`: Task with id is related.
 - `childOf`: Task with id is parent.
+
+### progress
+
+The progress property is extended by the following values:
+
+`deferred` - Indicates the task has been deferred or is waiting on someone
+
+`resolved` - Indicates the task has been resolved
+
+`needs-feedback` - Indicates the task is waiting on feedback
+
+`confirmed` - Indicates the task has been confirmed
+
+Mapping the status correctly to the present values of the Task can be challenging. In the most simple case tasks can have two states - done or not done. On the other hand, tasks can have various domain-specific statuses. Here are some recommendations for mapping more common values that SHOULD be used:
+
+`needs-action` - `not-done` (most simple case), `not-started`, `new`, …
+
+`in-process` - `in-progress`, `active`, `assigned`, …
+
+`completed` - `done` (most simple case), `closed`, `verified`, …
 
 ## Participants
 The Participant object, as defined in [@!I-D.ietf-calext-jscalendar] Section 4.4.6 is used to represent participants. This spec extends the keys for the roles property with the following value:

--- a/spec/tasks/task.mdown
+++ b/spec/tasks/task.mdown
@@ -98,6 +98,12 @@ Type: `UnignedInt|null` (default: null)
 
 This specifies the estimated amount of work the task takes to complete. The number is an abstract value without any actual unit, similar to Agile/Scrum complexity points.
 
+### impact
+
+Type: `String|null` (default: null)
+
+This specificies the impact or severity of the task. Some examples are: minor, trivial, major or block.
+
 ## Participants
 The Participant object, as defined in [@!I-D.ietf-calext-jscalendar] Section 4.4.6 is used to represent participants. This spec extends the keys for the roles property with the following value:
 

--- a/spec/tasks/task.mdown
+++ b/spec/tasks/task.mdown
@@ -92,6 +92,12 @@ Mapping the status correctly to the present values of the Task can be challengin
 
 `completed` - `done` (most simple case), `closed`, `verified`, …
 
+### estimatedWork
+
+Type: `UnignedInt|null` (default: null)
+
+This specifies the estimated amount of work the task takes to complete. The number is an abstract value without any actual unit, similar to Agile/Scrum complexity points.
+
 ## Participants
 The Participant object, as defined in [@!I-D.ietf-calext-jscalendar] Section 4.4.6 is used to represent participants. This spec extends the keys for the roles property with the following value:
 


### PR DESCRIPTION
Mainly contains changes to `Task` that resulted from [Task Survey](https://gist.github.com/jaudriga/cd323fa75397c76b1dd30861ef590302). Also contains a minor change that was brought up during last IETF 112.

Changes have been published at https://datatracker.ietf.org/doc/draft-ietf-jmap-tasks/03/ .