### PR TITLE
JMAP Tasks - IETF 113 changes

### DIFF
--- a/rfc/src/tasks.mdown
+++ b/rfc/src/tasks.mdown
@@ -2,17 +2,17 @@
     title = "JMAP for Tasks"
     abbrev = "JMAP Tasks"
     category = "std"
-    docName = "draft-baum-jmap-tasks-00"
+    docName = "draft-ietf-jmap-tasks-03"
     ipr = "trust200902"
     area = "Applications"
     workgroup = "JMAP"
     keyword = ["JMAP", "JSON", "tasks"]
 
-    date = 2021-10-25T00:00:00Z
+    date = 2022-03-07T00:00:00Z
 
     [seriesInfo]
     name="Internet-Draft"
-    value="draft-ietf-jmap-tasks-02"
+    value="draft-ietf-jmap-tasks-03"
     stream="IETF"
     status="standard"
 

--- a/rfc/src/tasks.mdown
+++ b/rfc/src/tasks.mdown
@@ -2,17 +2,17 @@
     title = "JMAP for Tasks"
     abbrev = "JMAP Tasks"
     category = "std"
-    docName = "draft-ietf-jmap-tasks-03"
+    docName = "draft-ietf-jmap-tasks-04"
     ipr = "trust200902"
     area = "Applications"
     workgroup = "JMAP"
     keyword = ["JMAP", "JSON", "tasks"]
 
-    date = 2022-03-07T00:00:00Z
+    date = 2022-05-09T00:00:00Z
 
     [seriesInfo]
     name="Internet-Draft"
-    value="draft-ietf-jmap-tasks-03"
+    value="draft-ietf-jmap-tasks-04"
     stream="IETF"
     status="standard"
 
@@ -26,9 +26,9 @@
         email = "joris@audriga.com"
         uri = "https://www.audriga.com"
         [author.address.postal]
-            street = "Durlacher Allee 47"
+            street = "Alter Schlachthof 57"
             city = "Karlsruhe "
-            code = "76131"
+            code = "76137"
             country = "Germany"
 
     [[author]]
@@ -41,9 +41,9 @@
         email = "hans-joerg@audriga.com"
         uri = "https://www.audriga.com"
         [author.address.postal]
-            street = "Durlacher Allee 47"
+            street = "Alter Schlachthof 57"
             city = "Karlsruhe "
-            code = "76131"
+            code = "76137"
             country = "Germany"
 %%%
 

--- a/spec/tasks/intro.mdown
+++ b/spec/tasks/intro.mdown
@@ -20,7 +20,7 @@ The terms ParticipantIdentity, TaskList, Task and TaskNotification are used to r
 
 ## Data Model Overview
 
-Similar to JMAP for Calendar, an Account (see [@!RFC8620], Section 1.6.2) contains zero or more TaskList objects, which is a named collection of Tasks belonging to a Principal (see [@!I-D.ietf-jmap-sharing] Section XXX). Task lists can also provide defaults, such as alerts and a color to apply to tasks in the calendar. Clients commonly let users toggle visibility of tasks belonging to a particular task list on/off. Servers may allow a task to belong to multiple TaskLists within an account.
+Similar to JMAP for Calendar, an Account (see [@!RFC8620], Section 1.6.2) contains zero or more TaskList objects, which is a named collection of Tasks belonging to a Principal (see [@!I-D.ietf-jmap-sharing] Section XXX). Task lists can also provide defaults, such as alerts and a color to apply to tasks in the calendar. Clients commonly let users toggle visibility of tasks belonging to a particular task list on/off.
 
 A Task is a representation of a single task or recurring series of Tasks in JSTask [@!I-D.ietf-calext-jscalendar] format. Recurrence rules and alerts as defined in JMAP for Calendars (see [@!I-D.ietf-jmap-calendars] Section XXX) apply.
 

--- a/spec/tasks/intro.mdown
+++ b/spec/tasks/intro.mdown
@@ -4,7 +4,7 @@ JMAP ([@!RFC8620] – JSON Meta Application Protocol) is a generic protocol for 
 
 JMAP for Calendars ([@!I-D.ietf-jmap-calendars]) defines a data model for synchronizing calendar data between a client and a server using JMAP. The data model is designed to allow a server to provide consistent access to the same data via CalDAV [@?RFC4791] as well as JMAP.
 
-While CalDAV defines access to tasks, JMAP for Calendars does not. This specification fills this gap and defines a data model for synchronizing task data between a client and a server using JMAP. It is built upon JMAP for Calendars and reuses most of its definitions. For better readability this document only outlines differences between this specification and JMAP for Calendars. If not stated otherwise, the same specifics that apply to Calendar, CalendarEvent and CalendarEventNotification objects as defined in the aforemetioned specification also apply to similar data types introduced in this specification.
+While CalDAV defines access to tasks, JMAP for Calendars does not. This specification fills this gap and defines a data model for synchronizing task data between a client and a server using JMAP. It is built upon JMAP for Calendars and reuses most of its definitions. For better readability, this document only outlines differences between this specification and JMAP for Calendars. If not stated otherwise, the same specifics that apply to Calendar, CalendarEvent and CalendarEventNotification objects as defined in the aforementioned specification also apply to similar data types introduced in this specification.
 
 ## Notational Conventions
 
@@ -20,21 +20,23 @@ The terms ParticipantIdentity, TaskList, Task and TaskNotification are used to r
 
 ## Data Model Overview
 
-Similar to JMAP for Calendar, an Account (see [@!RFC8620], Section 1.6.2) contains zero or more TaskList objects, which is a named collection of Tasks belonging to a Principal (see [@!I-D.ietf-jmap-sharing] Section XXX). Task lists can also provide defaults, such as alerts and a color to apply to tasks in the calendar. Clients commonly let users toggle visibility of tasks belonging to a particular task list on/off.
+Similar to JMAP for Calendar, an Account (see [@!RFC8620], Section 1.6.2) contains zero or more TaskList objects, which is a named collection of Tasks belonging to a Principal (see [@!I-D.ietf-jmap-sharing] Section XXX). Task lists can also provide defaults, such as alerts and a color, to apply to tasks in the calendar. Clients commonly let users toggle visibility of tasks belonging to a particular task list on/off.
 
 A Task is a representation of a single task or recurring series of Tasks in JSTask [@!I-D.ietf-calext-jscalendar] format. Recurrence rules and alerts as defined in JMAP for Calendars (see [@!I-D.ietf-jmap-calendars] Section XXX) apply.
 
 Just like the CalendarEventNotification objects (see [@!I-D.ietf-jmap-calendars] Section XXX), TaskNotification objects keep track of the history of changes made to a task by other users. Similarly, the ShareNotification type (see [@!I-D.ietf-jmap-sharing] Section XXX) notifies the user when their access to another user's task list is granted or revoked.
 
+Use cases for task systems vary. Only a few systems will require implementation of all available features defined within this specification. For this reason, this document describes several extensions to the core task properties and objects through which support for a certain feature MUST be advertised via capabilities. In addition to the core features advertised via `urn:ietf:params:jmap:tasks` support for recurrences, assignees, alerts, localizations as well as custom time zones can be advertised.
+
 ## Addition to the Capabilities Object
 
-The capabilities object is returned as part of the JMAP Session object; see [@!RFC8620], Section 2. This document defines one additional capability URI.
+The capabilities object is returned as part of the JMAP Session object; see [@!RFC8620], Section 2. This document defines six additional capability URIs.
 
 ### urn:ietf:params:jmap:tasks
 
-This represents support for the TaskList, Task and TaskNotification data types and associated API methods. The value of this property in the JMAP Session capabilities property is an empty object.
+This represents support for the core properties and objects of the TaskList, Task and TaskNotification data types and associated API methods. The value of this property in the JMAP Session capabilities property is an empty object.
 
-The value of this property in an account’s accountCapabilities property is an object that MUST contain the following information on server capabilities and permissions for that account:
+The value of this property in an account's accountCapabilities property is an object that MUST contain the following information on server capabilities and permissions for that account:
 
 - **shareesActAs**: `String`
   This MUST be one of:
@@ -46,9 +48,35 @@ The value of this property in an account’s accountCapabilities property is an 
   The earliest date-time the server is willing to accept for any date stored in a Task.
 - **maxDateTime**: `LocalDate`
   The latest date-time the server is willing to accept for any date stored in a Task.
-- **maxExpandedQueryDuration**: `Duration`
-  The maximum duration the user may query over when asking the server to expand recurrences.
-- **maxParticipantsPerTask**: `Number|null`
-  The maximum number of participants a single task may have, or null for no limit.
 - **mayCreateTaskList**: `Boolean`
   If true, the user may create a task list in this account.
+
+### urn:ietf:params:jmap:tasks:recurrences
+
+This represents support for the recurrence properties and objects of the TaskList, Task and TaskNotification data types and associated API methods. The value of this property in the JMAP Session capabilities property is an empty object.
+
+The value of this property in an account's accountCapabilities property is an object that MUST contain the following information on server capabilities and permissions for that account:
+
+- **maxExpandedQueryDuration**: `Duration`
+  The maximum duration the user may query over when asking the server to expand recurrences.
+
+### urn:ietf:params:jmap:tasks:assignees
+
+This represents support for the assignee properties and objects of the TaskList, Task and TaskNotification data types and associated API methods. The value of this property in the JMAP Session capabilities property is an empty object.
+
+The value of this property in an account's accountCapabilities property is an object that MUST contain the following information on server capabilities and permissions for that account:
+
+- **maxParticipantsPerTask**: `Number|null`
+  The maximum number of participants a single task may have, or null for no limit.
+
+### urn:ietf:params:jmap:tasks:alerts
+
+This represents support for the alerts properties and objects of the TaskList, Task and TaskNotification data types and associated API methods. The value of this property in the JMAP Session capabilities property and the account's accountCapabilities property is an empty object.
+
+### urn:ietf:params:jmap:tasks:multilingual
+
+This represents support for the multilingual properties and objects of the TaskList, Task and TaskNotification data types and associated API methods. The value of this property in the JMAP Session capabilities property and the account's accountCapabilities property is an empty object.
+
+### urn:ietf:params:jmap:tasks:customtimezones
+
+This represents support for the custom time zone properties and objects of the TaskList, Task and TaskNotification data types and associated API methods. The value of this property in the JMAP Session capabilities property and the account's accountCapabilities property is an empty object.

--- a/spec/tasks/list.mdown
+++ b/spec/tasks/list.mdown
@@ -23,6 +23,12 @@ A **TaskList** object has the following properties:
 
     The color SHOULD have sufficient contrast to be used as text on a white background.
 
+- **keywordColors** `String[String]|null` (default:null)
+  A map of keywords to the colors used when displaying the keywords associated to a task. The same considerations as for color above, apply.
+
+- **categoryColors** `String[String]|null` (default:null)
+  A map of categories to the colors used when displaying the categories associated to a task. The same considerations as for color above, apply.
+
 - **sortOrder**: `UnsignedInt` (default: 0)
   Defines the sort order of task lists when presented in the client's UI, so it
   is consistent between devices. The number MUST be an integer in the range

--- a/spec/tasks/list.mdown
+++ b/spec/tasks/list.mdown
@@ -25,10 +25,8 @@ A **TaskList** object has the following properties:
 
 - **keywordColors** `String[String]|null` (default:null)
   A map of keywords to the colors used when displaying the keywords associated to a task. The same considerations as for color above, apply.
-
 - **categoryColors** `String[String]|null` (default:null)
   A map of categories to the colors used when displaying the categories associated to a task. The same considerations as for color above, apply.
-
 - **sortOrder**: `UnsignedInt` (default: 0)
   Defines the sort order of task lists when presented in the client's UI, so it
   is consistent between devices. The number MUST be an integer in the range
@@ -49,6 +47,16 @@ A **TaskList** object has the following properties:
   A map of alert ids to Alert objects (see [@!I-D.ietf-calext-jscalendar], Section 4.5.2) to apply for tasks where "showWithoutTime" is true and "useDefaultAlerts" is true. Ids MUST be unique across all default alerts in the account, including those in other task lists; a UUID is recommended.
 - **timeZone**: `String|null` (default: null)
   The time zone to use for tasks without a time zone when the server needs to resolve them into absolute time, e.g., for alerts or availability calculation. The value MUST be a time zone id from the IANA Time Zone Database [TZDB](https://www.iana.org/time-zones). If `null`, the timeZone of the account's associated Principal will be used. Clients SHOULD use this as the default for new tasks in this task list if set.
+- **workflowStatuses**: `String[]` (default: [completed, failed, in-process, needs-action, cancelled, pending])
+  Defines the allowed values for `workflowStatus`. The default values are based the values defined within [@!I-D.ietf-calext-jscalendar], Section 5.2.5 and `pending`. `pending` indicates the task has been created and accepted, but has not yet started.
+
+    As naming and workflows differ between systems, mapping the status correctly to the present values of the Task can be challenging. In the most simple case a task system may support merely two states - done and not-done. On the other hand, statuses and their semantic meaning can differ between systems or task lists (e.g. projects). In case of uncertainty, here are some recommendations for mapping commonly observed values that can help during implementation:
+
+    - `completed`: `done` (most simple case), `closed`, `verified`, …
+    - `in-process`: `in-progress`, `active`, `assigned`, …
+    - `needs-action`: `not-done` (most simple case), `not-started`, `new`, …
+    - `pending`: `waiting`, `deferred`
+
 - **shareWith**: `Id[TaskRights]|null` (default: null)
   A map of Principal id to rights for principals this task list is shared with. The principal to which this task list belongs MUST NOT be in this set. This is null if the user requesting the object does not have the mayAdmin right, or if the task list  is not shared with anyone. May be modified only if the user has the mayAdmin right. The account id for the principals may be found in the `urn:ietf:params:jmap:principals:owner` capability of the Account to which the task list belongs.
 

--- a/spec/tasks/list.mdown
+++ b/spec/tasks/list.mdown
@@ -114,10 +114,15 @@ A task has no owner if its participant property is null or omitted.
 
 A TaskList has the following alerts properties:
 
-- **defaultAlertsWithTime**: `Id[Alert]|null` (default: null)
+- **defaultAlertsWithTime**: `Id[Alert]|null`
   A map of alert ids to Alert objects (see [@!I-D.ietf-calext-jscalendar], Section 4.5.2) to apply for tasks where "showWithoutTime" is false and "useDefaultAlerts" is true. Ids MUST be unique across all default alerts in the account, including those in other task lists; a UUID is recommended.
-- **defaultAlertsWithoutTime**: `Id[Alert]|null` (default: null)
+
+    If omitted on creation, the default is server dependent. For example, servers may choose to always default to `null`, or may copy the alerts from the default task list.
+
+- **defaultAlertsWithoutTime**: `Id[Alert]|null`
   A map of alert ids to Alert objects (see [@!I-D.ietf-calext-jscalendar], Section 4.5.2) to apply for tasks where "showWithoutTime" is true and "useDefaultAlerts" is true. Ids MUST be unique across all default alerts in the account, including those in other task lists; a UUID is recommended.
+
+      If omitted on creation, the default is server dependent. For example, servers may choose to always default to `null`, or may copy the alerts from the default task list.
 
 ## TaskList/get
 

--- a/spec/tasks/list.mdown
+++ b/spec/tasks/list.mdown
@@ -148,7 +148,9 @@ When modifying the shareWith property, the user cannot give a right to a princip
 
 Users can subscribe or unsubscribe to a task list by setting the "isSubscribed" property. The server MAY forbid users from subscribing to certain task lists even though they have permission to see them, rejecting the update with a `forbidden` SetError.
 
-The "timeZone", "defaultAlertsWithoutTime" and "defaultAlertsWithTime" properties are stored per-user if the task list account's "shareesActAs" capability is "self", and may be set by any user who is subscribed to the task list. Otherwise, these properties are shared, and may only be set by users that have the mayAdmin right.
+The "timeZone", "defaultAlertsWithoutTime" and "defaultAlertsWithTime" properties are stored per-user if the task list account's "shareesActAs" capability is "self", and may be set by any user who is subscribed to the task list and has the mayUpdatePrivate right. Each user gets the default value for these properties as the initial value; they do not inherit an initial value from the task list owner.
+
+If the task list account's "shareesActAs" capability is "secretary" these properties are instead shared, and may only be set by users that have the mayAdmin right.
 
 The following properties may be set by anyone who is subscribed to the task list and are all stored per-user:
 
@@ -156,7 +158,9 @@ The following properties may be set by anyone who is subscribed to the task list
 - color
 - sortOrder
 
-These properties are initially inherited from the owner's copy of the task list, but if set by a sharee that user gets their own copy of the property; it does not change for any other principals. If the value of the property in the owner's task list changes after this, it does not overwrite the sharee's value.
+The "name" and "color" properties are initially inherited from the owner's copy of the task list, but if set by a sharee that user gets their own copy of the property; it does not change for any other principals. If the value of the property in the owner's task list changes after this, it does not overwrite the sharee's value.
+
+The "sortOrder" property is initally the default value for each sharee; it is not inherited from the owner.
 
 The following extra SetError types are defined:
 

--- a/spec/tasks/list.mdown
+++ b/spec/tasks/list.mdown
@@ -24,9 +24,9 @@ A **TaskList** object has the following core properties:
     The color SHOULD have sufficient contrast to be used as text on a white background.
 
 - **keywordColors** `String[String]|null` (default:null)
-  A map of keywords to the colors used when displaying the keywords associated to a task. The same considerations as for color above, apply.
+  A map of keywords to the colors used when displaying the keywords associated to a task. The same considerations, as for color above, apply.
 - **categoryColors** `String[String]|null` (default:null)
-  A map of categories to the colors used when displaying the categories associated to a task. The same considerations as for color above, apply.
+  A map of categories to the colors used when displaying the categories associated to a task. The same considerations, as for color above, apply.
 - **sortOrder**: `UnsignedInt` (default: 0)
   Defines the sort order of task lists when presented in the client's UI, so it
   is consistent between devices. The number MUST be an integer in the range
@@ -36,17 +36,17 @@ A **TaskList** object has the following core properties:
     a higher order in any list of task lists in the client's UI. Task lists with equal order SHOULD be sorted in alphabetical order by name. The sorting should take into account locale-specific character order convention.
 
 - **isSubscribed**: `Boolean`
-  Has the user indicated they wish to see this task list in their client? This SHOULD default to false for task lists in shared accounts the user has access to and true for any new task list created by the user themselves.
+  Has the user indicated they wish to see this task list in their client? This SHOULD default to false for task lists in shared accounts the user has access to, and true for any new task list created by the user themselves.
 
     If false, the task list should only be displayed when the user explicitly
     requests it or to offer it for the user to subscribe to.
 
 - **timeZone**: `String|null` (default: null)
-  The time zone to use for tasks without a time zone when the server needs to resolve them into absolute time, e.g., for alerts or availability calculation. The value MUST be a time zone id from the IANA Time Zone Database [TZDB](https://www.iana.org/time-zones). If `null`, the timeZone of the account's associated Principal will be used. Clients SHOULD use this as the default for new tasks in this task list if set.
+  The time zone to use for tasks without a time zone when the server needs to resolve them into absolute time, e.g., for alerts or availability calculation. The value MUST be a time zone id from the IANA Time Zone Database [TZDB](https://www.iana.org/time-zones). If `null`, the timeZone of the account's associated Principal will be used. Clients SHOULD use this as the default for new tasks in this task list, if set.
 - **workflowStatuses**: `String[]` (default: [completed, failed, in-process, needs-action, cancelled, pending])
   Defines the allowed values for `workflowStatus`. The default values are based the values defined within [@!I-D.ietf-calext-jscalendar], Section 5.2.5 and `pending`. `pending` indicates the task has been created and accepted, but has not yet started.
 
-    As naming and workflows differ between systems, mapping the status correctly to the present values of the Task can be challenging. In the most simple case a task system may support merely two states - done and not-done. On the other hand, statuses and their semantic meaning can differ between systems or task lists (e.g. projects). In case of uncertainty, here are some recommendations for mapping commonly observed values that can help during implementation:
+    As naming and workflows differ between systems, mapping the status correctly to the present values of the Task can be challenging. In the most simple case, a task system may support merely two states - done and not-done. On the other hand, statuses and their semantic meaning can differ between systems or task lists (e.g. projects). In case of uncertainty, here are some recommendations for mapping commonly observed values that can help during implementation:
 
     - `completed`: `done` (most simple case), `closed`, `verified`, …
     - `in-process`: `in-progress`, `active`, `assigned`, …
@@ -140,7 +140,7 @@ This is the "Calendar/set" method as described in [@!I-D.ietf-jmap-calendars], S
 
   If false, any attempt to destroy a TaskList that still has Tasks 
   in it will be rejected with a `TaskListHasTask` SetError. If
-  true, any Tasks that were in the TaskList will be removed from it and they will be destroyed.
+  true, any Tasks that were in the TaskList will be removed from it, and they will be destroyed.
 
 The "role" and "shareWith" properties may only be set by users that have the mayAdmin right. The value is shared across all users, although users without the mayAdmin right cannot see the value.
 
@@ -166,5 +166,5 @@ The following extra SetError types are defined:
 
 For "destroy":
 
-- **taskListHasTask**: The Task List has at least one Task assigned to
+- **taskListHasTask**: The Task List has at least one task assigned to
   it, and the "onDestroyRemoveTasks" argument was false.

--- a/spec/tasks/list.mdown
+++ b/spec/tasks/list.mdown
@@ -2,7 +2,7 @@
 
 A TaskList is a named collection of tasks. All tasks are associated with exactly one TaskList.
 
-A **TaskList** object has the following properties:
+A **TaskList** object has the following core properties:
 
 - **id**: `Id` (immutable; server-set)
   The id of the task list.
@@ -41,10 +41,6 @@ A **TaskList** object has the following properties:
     If false, the task list should only be displayed when the user explicitly
     requests it or to offer it for the user to subscribe to.
 
-- **defaultAlertsWithTime**: `Id[Alert]|null` (default: null)
-  A map of alert ids to Alert objects (see [@!I-D.ietf-calext-jscalendar], Section 4.5.2) to apply for tasks where "showWithoutTime" is false and "useDefaultAlerts" is true. Ids MUST be unique across all default alerts in the account, including those in other task lists; a UUID is recommended.
-- **defaultAlertsWithoutTime**: `Id[Alert]|null` (default: null)
-  A map of alert ids to Alert objects (see [@!I-D.ietf-calext-jscalendar], Section 4.5.2) to apply for tasks where "showWithoutTime" is true and "useDefaultAlerts" is true. Ids MUST be unique across all default alerts in the account, including those in other task lists; a UUID is recommended.
 - **timeZone**: `String|null` (default: null)
   The time zone to use for tasks without a time zone when the server needs to resolve them into absolute time, e.g., for alerts or availability calculation. The value MUST be a time zone id from the IANA Time Zone Database [TZDB](https://www.iana.org/time-zones). If `null`, the timeZone of the account's associated Principal will be used. Clients SHOULD use this as the default for new tasks in this task list if set.
 - **workflowStatuses**: `String[]` (default: [completed, failed, in-process, needs-action, cancelled, pending])
@@ -70,7 +66,6 @@ A **TaskList** object has the following properties:
     task list.
   - The user may make other changes to the task if they have the right to do
     so in *all* task list to which the task belongs.
-
 
 A **TaskRights** object has the following properties:
 
@@ -114,6 +109,15 @@ The user is an **owner** for a task if the Task object has a "participant" prope
 1. Corresponds to one of the user's ParticipantIdentity objects in the account.
   
 A task has no owner if its participant property is null or omitted.
+
+## Alerts extension
+
+A TaskList has the following alerts properties:
+
+- **defaultAlertsWithTime**: `Id[Alert]|null` (default: null)
+  A map of alert ids to Alert objects (see [@!I-D.ietf-calext-jscalendar], Section 4.5.2) to apply for tasks where "showWithoutTime" is false and "useDefaultAlerts" is true. Ids MUST be unique across all default alerts in the account, including those in other task lists; a UUID is recommended.
+- **defaultAlertsWithoutTime**: `Id[Alert]|null` (default: null)
+  A map of alert ids to Alert objects (see [@!I-D.ietf-calext-jscalendar], Section 4.5.2) to apply for tasks where "showWithoutTime" is true and "useDefaultAlerts" is true. Ids MUST be unique across all default alerts in the account, including those in other task lists; a UUID is recommended.
 
 ## TaskList/get
 

--- a/spec/tasks/task.mdown
+++ b/spec/tasks/task.mdown
@@ -34,9 +34,6 @@ A **Task** object contains information about a task, or recurring series of task
     A task with a lower order should be displayed before a task with
     a higher order in any list of tasks in the client's UI. Tasks with equal order SHOULD be sorted in alphabetical order by name. The sorting should take into account locale-specific character order convention.
 
-- **source**: `String|null` (default: null)
-  The source of the task like "Web app", "Mobile client" or "Email".
-
 ## Extensions to JSCalendar data types
 
 This document extends one data type with new values.

--- a/spec/tasks/task.mdown
+++ b/spec/tasks/task.mdown
@@ -96,7 +96,7 @@ Mapping the status correctly to the present values of the Task can be challengin
 
 Type: `UnignedInt|null` (default: null)
 
-This specifies the estimated amount of work the task takes to complete. The number is an abstract value without any actual unit, similar to Agile/Scrum complexity points.
+This specifies the estimated amount of work the task takes to complete. The number SHOULD be in Fibonacci scale without any actual unit. In the of Agile software development or Scrum it is known as complexity or story points.
 
 ### impact
 

--- a/spec/tasks/task.mdown
+++ b/spec/tasks/task.mdown
@@ -34,6 +34,9 @@ A **Task** object contains information about a task, or recurring series of task
     A task with a lower order should be displayed before a task with
     a higher order in any list of tasks in the client's UI. Tasks with equal order SHOULD be sorted in alphabetical order by name. The sorting should take into account locale-specific character order convention.
 
+- **source**: `String|null` (default: null)
+  The source of the task like "Web app", "Mobile client" or "Email".
+
 ## Additional JSCalendar properties
 
 This document defines four new JSCalendar properties and extends one properties with new values.

--- a/spec/tasks/task.mdown
+++ b/spec/tasks/task.mdown
@@ -102,7 +102,7 @@ This specifies the estimated amount of work the task takes to complete. The numb
 
 Type: `String|null` (default: null)
 
-This specificies the impact or severity of the task. Some examples are: minor, trivial, major or block.
+This specifies the impact or severity of the task, but does not say anything about prioritization. Usually, the priority of a task is based upon its impact and urgency. Some examples are: minor, trivial, major or block.
 
 ## Participants
 The Participant object, as defined in [@!I-D.ietf-calext-jscalendar] Section 4.4.6 is used to represent participants. This spec extends the keys for the roles property with the following value:

--- a/spec/tasks/task.mdown
+++ b/spec/tasks/task.mdown
@@ -34,6 +34,9 @@ A **Task** object contains information about a task, or recurring series of task
     A task with a lower order should be displayed before a task with
     a higher order in any list of tasks in the client's UI. Tasks with equal order SHOULD be sorted in alphabetical order by name. The sorting should take into account locale-specific character order convention.
 
+- **workflowStatus**: `String|null` (default: null)
+  Specifies the status of the task. The allowed values are defined within `workflowStatuses`. If set, `progress` MUST null.
+
 ## Extensions to JSCalendar data types
 
 This document extends one data type with new values.
@@ -49,7 +52,7 @@ The keys for `relation` of the `Relation` object are extended by the following v
 
 ## Additional JSCalendar properties
 
-This document defines five new JSCalendar properties and extends one properties with new values.
+This document defines five new JSCalendar properties.
 
 ### mayInviteSelf
 
@@ -68,26 +71,6 @@ If `true`, any current participant with the "attendee" role may add new particip
 Type: `Boolean` (default: false)
 
 If `true`, only the owners of the task may see the full set of participants. Other sharees of the task may only see the owners and themselves. This property MUST NOT be altered in the recurrenceOverrides; it may only be set on the master object.
-
-### progress
-
-The progress property is extended by the following values:
-
-`deferred` - Indicates the task has been deferred or is waiting on someone
-
-`resolved` - Indicates the task has been resolved
-
-`needs-feedback` - Indicates the task is waiting on feedback
-
-`confirmed` - Indicates the task has been confirmed
-
-Mapping the status correctly to the present values of the Task can be challenging. In the most simple case tasks can have two states - done or not done. On the other hand, tasks can have various domain-specific statuses. Here are some recommendations for mapping more common values that SHOULD be used:
-
-`needs-action` - `not-done` (most simple case), `not-started`, `new`, …
-
-`in-process` - `in-progress`, `active`, `assigned`, …
-
-`completed` - `done` (most simple case), `closed`, `verified`, …
 
 ### estimatedWork
 

--- a/spec/tasks/task.mdown
+++ b/spec/tasks/task.mdown
@@ -1,5 +1,4 @@
 # Tasks
-
 A **Task** object contains information about a task, or recurring series of tasks. It is a JSTask object, as defined in [@!I-D.ietf-calext-jscalendar], with the following additional properties:
 
 - **id**: `Id`
@@ -37,7 +36,7 @@ A **Task** object contains information about a task, or recurring series of task
 
 ## Additional JSCalendar properties
 
-This document defines four new JSCalendar properties.
+This document defines four new JSCalendar properties and extends one properties with new values.
 
 ### mayInviteSelf
 
@@ -69,6 +68,26 @@ A map of task ids to relations. Relation SHOULD be one of:
 - `causedBy`: Task with id was the cause for this task.
 - `relatesTo`: Task with id is related.
 - `childOf`: Task with id is parent.
+
+### progress
+
+The progress property is extended by the following values:
+
+`deferred` - Indicates the task has been deferred or is waiting on someone
+
+`resolved` - Indicates the task has been resolved
+
+`needs-feedback` - Indicates the task is waiting on feedback
+
+`confirmed` - Indicates the task has been confirmed
+
+Mapping the status correctly to the present values of the Task can be challenging. In the most simple case tasks can have two states - done or not done. On the other hand, tasks can have various domain-specific statuses. Here are some recommendations for mapping more common values that SHOULD be used:
+
+`needs-action` - `not-done` (most simple case), `not-started`, `new`, …
+
+`in-process` - `in-progress`, `active`, `assigned`, …
+
+`completed` - `done` (most simple case), `closed`, `verified`, …
 
 ## Participants
 The Participant object, as defined in [@!I-D.ietf-calext-jscalendar] Section 4.4.6 is used to represent participants. This spec extends the keys for the roles property with the following value:

--- a/spec/tasks/task.mdown
+++ b/spec/tasks/task.mdown
@@ -98,6 +98,12 @@ Type: `UnignedInt|null` (default: null)
 
 This specifies the estimated amount of work the task takes to complete. The number is an abstract value without any actual unit, similar to Agile/Scrum complexity points.
 
+### impact
+
+Type: `String|null` (default: null)
+
+This specificies the impact or severity of the task. Some examples are: minor, trivial, major or block.
+
 ## Participants
 The Participant object, as defined in [@!I-D.ietf-calext-jscalendar] Section 4.4.6 is used to represent participants. This spec extends the keys for the roles property with the following value:
 

--- a/spec/tasks/task.mdown
+++ b/spec/tasks/task.mdown
@@ -37,9 +37,22 @@ A **Task** object contains information about a task, or recurring series of task
 - **source**: `String|null` (default: null)
   The source of the task like "Web app", "Mobile client" or "Email".
 
+## Extensions to JSCalendar data types
+
+This document extends one data type with new values.
+
+### Relation
+
+The keys for `relation` of the `Relation` object are extended by the following values:
+
+- `depends-on`: This task depends on the referenced task in some manner. For example, a task may be blocked waiting on the other, referenced, task.
+- `clone`: The referenced task was cloned from this task.
+- `duplicate`: The referenced task is a duplicate of this task.
+- `cause`: The referenced task was the cause for this task.
+
 ## Additional JSCalendar properties
 
-This document defines four new JSCalendar properties and extends one properties with new values.
+This document defines five new JSCalendar properties and extends one properties with new values.
 
 ### mayInviteSelf
 
@@ -58,19 +71,6 @@ If `true`, any current participant with the "attendee" role may add new particip
 Type: `Boolean` (default: false)
 
 If `true`, only the owners of the task may see the full set of participants. Other sharees of the task may only see the owners and themselves. This property MUST NOT be altered in the recurrenceOverrides; it may only be set on the master object.
-
-### relatedTo 
-
-Type: `Id[String]|null` (default: null)
-
-A map of task ids to relations. Relation SHOULD be one of:
-
-- `blockedBy`: Blocked by task with id.
-- `clonedBy`: Task with id was cloned from this issue.
-- `duplicatedBy`: Task with id is a duplicate of this issue.
-- `causedBy`: Task with id was the cause for this task.
-- `relatesTo`: Task with id is related.
-- `childOf`: Task with id is parent.
 
 ### progress
 

--- a/spec/tasks/task.mdown
+++ b/spec/tasks/task.mdown
@@ -92,6 +92,12 @@ Mapping the status correctly to the present values of the Task can be challengin
 
 `completed` - `done` (most simple case), `closed`, `verified`, …
 
+### estimatedWork
+
+Type: `UnignedInt|null` (default: null)
+
+This specifies the estimated amount of work the task takes to complete. The number is an abstract value without any actual unit, similar to Agile/Scrum complexity points.
+
 ## Participants
 The Participant object, as defined in [@!I-D.ietf-calext-jscalendar] Section 4.4.6 is used to represent participants. This spec extends the keys for the roles property with the following value:
 

--- a/spec/tasks/task.mdown
+++ b/spec/tasks/task.mdown
@@ -26,7 +26,7 @@ On top of the JSTask properties, a Task object has the following additional core
 
     Floating tasks (tasks without a time zone) will be interpreted as per the time zone given as a Task/get argument.
 
-    Note that it is not possible to accurately calculate the expansion of recurrence rules or recurrence overrides with the utcStart property rather than the local start time. Even simple recurrences such as "repeat weekly" may cross a daylight-savings boundary and end up at a different UTC time. Clients that wish to use "utcStart" are RECOMMENDED to request the server expand recurrences (see Section XXX).
+    Note that it is not possible to accurately calculate the expansion of recurrence rules or recurrence overrides with the utcStart property rather than the local start time. Even simple recurrences such as "repeat weekly" may cross a daylight-savings boundary and end up at a different UTC time. Clients that wish to use "utcStart" are RECOMMENDED to request the server to expand recurrences (see Section XXX).
 
 - **utcDue**: `UTCDate`
   The server calculates the end time in UTC from the start/timeZone/duration properties of the task. This is not included by default and must be requested explicitly. Like utcStart, this is calculated at fetch time if requested and may change due to time zone data changes. Floating tasks will be interpreted as per the time zone given as a Task/get argument.
@@ -95,7 +95,7 @@ Attachments and per-user properties are described in [@!I-D.ietf-jmap-calendars]
 
 ## Recurrences extension
 
-For the recurrence extension the JSCalendar objects NDay and RecurrenceRule as well as the Recurrence Properties (Section 4.3) need to be supported.
+For the recurrence extension, the JSCalendar objects NDay and RecurrenceRule as well as the Recurrence Properties (Section 4.3) need to be supported.
 
 ### Properties similar in JMAP for Calendar
 
@@ -103,7 +103,7 @@ Recurrences and updates to recurrences are described in [@!I-D.ietf-jmap-calenda
 
 ## Assignees extension
 
-For the assignees extension the JSCalendar object Participant as well as all Sharing and Scheduling Properties (Section 4.4) need to be supported.
+For the assignees extension, the JSCalendar object Participant as well as all Sharing and Scheduling Properties (Section 4.4) need to be supported.
 
 ### Extensions to JSCalendar data types
 
@@ -116,15 +116,15 @@ The Participant object, as defined in [@!I-D.ietf-calext-jscalendar] Section 4.4
 
 ## Alerts extension
 
-For the alerts extension the JSCalendar objects Alert, AbsoluteTrigger and OffsetTrigger as well as all Alerts Properties (Section 4.4) need to be supported.
+For the alerts extension, the JSCalendar objects Alert, AbsoluteTrigger and OffsetTrigger as well as all Alerts Properties (Section 4.4) need to be supported.
 
 ## Multilingual extension
 
-For the multilingual extension the JSCalendar Multilingual Properties (Section 4.6) need to be supported.
+For the multilingual extension, the JSCalendar Multilingual Properties (Section 4.6) need to be supported.
 
 ## Custom Time Zones extension
 
-For the custom time zones extension the JSCalendar objects TimeZone and TimeZoneRule as well as all Time Zone Properties (Section 4.7) need to be supported.
+For the custom time zones extension, the JSCalendar objects TimeZone and TimeZoneRule as well as all Time Zone Properties (Section 4.7) need to be supported.
 
 ## Task/get
 

--- a/spec/tasks/task.mdown
+++ b/spec/tasks/task.mdown
@@ -1,5 +1,10 @@
 # Tasks
-A **Task** object contains information about a task, or recurring series of tasks. It is a JSTask object, as defined in [@!I-D.ietf-calext-jscalendar], with the following additional properties:
+
+A **Task** object contains information about a task. It is a JSTask object, as defined in [@!I-D.ietf-calext-jscalendar]. However, as use-cases of task systems vary, this Section defines relevant parts of the JSTask object to implement the core task capability as well as several extensions to it. Only the core capability MUST be implemented by any task system. Implementers can choose the extensions that fit their own use case. For example, the recurrence extension allows having a Task object represent a series of recurring Tasks.
+
+The core JSTask objects are Task, Link, Location, Relation and VirtualLocation. The core properties are JSTask's Metadata Properties (Section 4.1), What and Where Properties (Section 4.2), Task Properties (Section 5.2) as well as priority (Section 4.4.1), privacy (Section 4.4.3), replyTo (Section 4.4.4) and timeZone (Section 4.7.1).
+
+On top of the JSTask properties, a Task object has the following additional core properties:
 
 - **id**: `Id`
   The id of the Task. This property is immutable. The id uniquely identifies a JSTask with a particular "uid" and "recurrenceId" within a particular account.
@@ -39,7 +44,7 @@ A **Task** object contains information about a task, or recurring series of task
 
 ## Extensions to JSCalendar data types
 
-This document extends one data type with new values.
+This document extends one JSCalendar data type with new values.
 
 ### Relation
 
@@ -52,7 +57,7 @@ The keys for `relation` of the `Relation` object are extended by the following v
 
 ## Additional JSCalendar properties
 
-This document defines five new JSCalendar properties.
+This document defines five new core JSCalendar properties for the JSTask object.
 
 ### mayInviteSelf
 
@@ -84,14 +89,42 @@ Type: `String|null` (default: null)
 
 This specifies the impact or severity of the task, but does not say anything about prioritization. Usually, the priority of a task is based upon its impact and urgency. Some examples are: minor, trivial, major or block.
 
-## Participants
+## Properties similar in JMAP for Calendar
+
+Attachments and per-user properties are described in [@!I-D.ietf-jmap-calendars], Section XXX.
+
+## Recurrences extension
+
+For the recurrence extension the JSCalendar objects NDay and RecurrenceRule as well as the Recurrence Properties (Section 4.3) need to be supported.
+
+### Properties similar in JMAP for Calendar
+
+Recurrences and updates to recurrences are described in [@!I-D.ietf-jmap-calendars], Section XXX
+
+## Assignees extension
+
+For the assignees extension the JSCalendar object Participant as well as all Sharing and Scheduling Properties (Section 4.4) need to be supported.
+
+### Extensions to JSCalendar data types
+
+The assignees extension extends one JSCalendar data type with new values.
+
+#### Participants
 The Participant object, as defined in [@!I-D.ietf-calext-jscalendar] Section 4.4.6 is used to represent participants. This spec extends the keys for the roles property with the following value:
 
 - `assignee`: the participant is expected to work on the task
 
-## Properties similar in JMAP for Calendar
+## Alerts extension
 
-Attachments, per-user properties, recurrences and updates to recurrences are described in [@!I-D.ietf-jmap-calendars], Section XXX.
+For the alerts extension the JSCalendar objects Alert, AbsoluteTrigger and OffsetTrigger as well as all Alerts Properties (Section 4.4) need to be supported.
+
+## Multilingual extension
+
+For the multilingual extension the JSCalendar Multilingual Properties (Section 4.6) need to be supported.
+
+## Custom Time Zones extension
+
+For the custom time zones extension the JSCalendar objects TimeZone and TimeZoneRule as well as all Time Zone Properties (Section 4.7) need to be supported.
 
 ## Task/get
 


### PR DESCRIPTION
Based on https://github.com/jmapio/jmap/pull/365 .

Ships draft-ietf-jmap-tasks-04 due to things discussed at IETF 113. Also aligns it with draft-ietf-calext-ical-relations, draft-ietf-calext-ical-tasks and draft-ietf-jmap-calendars-08.

More detailed changes:

- Renamed and clarified the relation types and use wording of draft-ietf-calext-ical-relations (only for depends-on).
- Further specify what we mean by `estimatedWork`
- Elaborate how `impact` differs from `priority`.
- Add `keywordColors` and `categoryColors`
- Throw out `source` as it is covered by `prodId`
- Add new `workflowStatus` and `workflowStatuses`
- Grouping!