### PR TITLE
Added Stalwart JMAP, jmap-client and Stalwart IMAP

### DIFF
--- a/software/software.mdown
+++ b/software/software.mdown
@@ -21,6 +21,7 @@
 * **[atmail](https://www.atmail.com/blog/jmap-rfc-8620/)** (golang, proprietary)
 * **[tmail-backend](https://github.com/linagora/tmail-backend)** (Java, Apache): builds on Apache James with extra features
 * **[hyper-auth-proxy](https://crates.io/crates/hyper-auth-proxy)** (Rust): A proxy to do HTTP basic auth from a JWT token and redis session credentials; build to add JWT bearer auth support to Cyrus's JMAP.
+* **[Stalwart JMAP](https://github.com/stalwartlabs/jmap-server/)** (Rust, AGPLv3): Open-source JMAP server designed to be robust, secure and scalable. Includes full support for JMAP Core, JMAP Mail and JMAP over WebSocket.
 
 ## Libraries
 
@@ -31,7 +32,10 @@
 * **[melib](https://meli.delivery)** (Rust): mail client library used in *meli* (GPLv3)
 * **[jmap-rs](https://gitlab.com/jmap-rs/jmap-rs)** (Rust; in development): Rust client (and maybe server) library for JMAP
 * **[jmapc](https://pypi.org/project/jmapc/)** (Python; [partially implemented](https://github.com/smkent/jmapc)): Python 3 client library for JMAP mail
+* **[jmap-client](https://github.com/stalwartlabs/jmap-client)** (Rust; Apache/MIT): JMAP client library written in Rust. Includes full support for JMAP Core, JMAP Mail and JMAP over WebSocket.
 
+## Proxies
+* **[Stalwart IMAP](https://github.com/stalwartlabs/imap-server/)** (Rust, AGPLv3): Open-source IMAP4-to-JMAP proxy. Supports IMAP4rev2, IMAP4rev1 and multiple extensions.
 
 ## Planned
 


### PR DESCRIPTION
Hi,

I would like to add to the list a new JMAP server written in Rust as well as a JMAP client library. I also added a new "Proxies" section including an IMAP-to-JMAP proxy that was released as well, feel free to move it to "Servers" if you feel it is more appropriate.

Thank you.
