### PR TITLE
Add jmap-jam library

### DIFF
--- a/software/software.mdown
+++ b/software/software.mdown
@@ -2,38 +2,38 @@
 
 ## Clients
 
+* **[Cypht](https://github.com/jasonmunro/cypht/issues/180)**: lightweight Open Source webmail written in PHP and JavaScript.
+* **[Group-Office](https://github.com/Intermesh/groupoffice)** (Javascript): Open source groupware and collaboration platform
 * **[JMAP Demo Webmail](https://github.com/jmapio/jmap-demo-webmail)** (JavaScript, MIT): a sophisticated demo webmail client to be used as a base for new projects. Default client for the [proxy](https://proxy.jmap.io).
 * **[JMAP::Tester](https://metacpan.org/pod/JMAP::Tester)** (Perl, Perl5): a JMAP client made for testing JMAP servers.
-* **[Cypht](https://github.com/jasonmunro/cypht/issues/180)**: lightweight Open Source webmail written in PHP and JavaScript.
 * **[Ltt.rs](https://github.com/iNPUTmice/lttrs-android)** (Java, Apache): an email client for Android
-* **[Group-Office](https://github.com/Intermesh/groupoffice)** (Javascript): Open source groupware and collaboration platform
-* **[meli](https://meli.delivery)** (Rust): terminal email client (GPLv3)
 * **[Mailtemi](https://mailtemi.com)** , a native iOS email client
-* **[tmail-flutter](https://github.com/linagora/tmail-flutter)** (Dart): Android, iOS client
+* **[meli](https://meli.delivery)** (Rust): terminal email client (GPLv3)
 * **[mujmap](https://github.com/elizagamedev/mujmap)** (Rust): Synchronize JMAP mail with [notmuch](https://notmuchmail.org)
+* **[tmail-flutter](https://github.com/linagora/tmail-flutter)** (Dart): Android, iOS client
 
 ## Servers
 
-* **[JMAP Proxy](https://github.com/jmapio/jmap-perl)** (Perl, MIT): a complete JMAP server implementation that uses any IMAP, CalDAV and CardDAV store as a backend. Also available as a hosted service at [proxy.jmap.io](https://proxy.jmap.io).
-* **[Cyrus IMAP](https://www.cyrusimap.org/imap/download/release-notes/3.0/x/3.0.3.html)** (C, BSD-style): A scalable enterprise-grade IMAP, CalDAV and CardDAV server. The 3.0 series is adding JMAP support, instructions to enable it are [here](https://www.cyrusimap.org/dev/imap/developer/jmap.html).
 * **[Apache James](http://james.apache.org/)** (Java, Apache): Apache James, a.k.a. Java Apache Mail Enterprise Server is an open source mail server written entirely in Java. The 3.0 series is adding JMAP support, upcoming 3.6.0 adds support for [JMAP over websocket](https://www.rfc-editor.org/rfc/rfc8887.html).
-* **[Group-Office](https://github.com/Intermesh/groupoffice)** (PHP): Open source groupware and collaboration platform
 * **[atmail](https://www.atmail.com/blog/jmap-rfc-8620/)** (golang, proprietary)
-* **[tmail-backend](https://github.com/linagora/tmail-backend)** (Java, Apache): builds on Apache James with extra features
+* **[Cyrus IMAP](https://www.cyrusimap.org/imap/download/release-notes/3.0/x/3.0.3.html)** (C, BSD-style): A scalable enterprise-grade IMAP, CalDAV and CardDAV server. The 3.0 series is adding JMAP support, instructions to enable it are [here](https://www.cyrusimap.org/dev/imap/developer/jmap.html).
+* **[Group-Office](https://github.com/Intermesh/groupoffice)** (PHP): Open source groupware and collaboration platform
 * **[hyper-auth-proxy](https://crates.io/crates/hyper-auth-proxy)** (Rust): A proxy to do HTTP basic auth from a JWT token and redis session credentials; build to add JWT bearer auth support to Cyrus's JMAP.
+* **[JMAP Proxy](https://github.com/jmapio/jmap-perl)** (Perl, MIT): a complete JMAP server implementation that uses any IMAP, CalDAV and CardDAV store as a backend. Also available as a hosted service at [proxy.jmap.io](https://proxy.jmap.io).
 * **[Stalwart JMAP](https://github.com/stalwartlabs/jmap-server/)** (Rust, AGPLv3): Open-source JMAP server designed to be robust, secure and scalable. Includes full support for JMAP Core, JMAP Mail, JMAP for Sieve, JMAP over WebSocket, JMAP for Quotas and JMAP Blob Management.
+* **[tmail-backend](https://github.com/linagora/tmail-backend)** (Java, Apache): builds on Apache James with extra features
 
 ## Libraries
 
-* **[JMAP-JS](https://github.com/jmapio/jmap-js)** (JavaScript, MIT): a full implementation of the JMAP mail, calendar and contacts model in JavaScript. It supports asynchronous local changes and is tolerant of network failure – actions will update the UI instantly, then synchronise changes back to the server when it can. It also has multi-level undo/redo support. Used by the [demo webmail](https://github.com/jmapio/jmap-demo-webmail).
-* **[jmap-client-ts](https://github.com/OpenPaaS-Suite/jmap-client-ts)** (TypeScript, MIT): a lightweight promise-based API to make JMAP requests.
-* **[zend-jmap](https://github.com/WikiSuite/zend-jmap)** (PHP, New BSD): JMAP for Zend Framework
+* **[go-jmap](https://sr.ht/~rockorager/go-jmap)** (Go, MIT): JMAP client library written in Go
 * **[Java JMAP Library](https://github.com/iNPUTmice/jmap)** (Java 7, Apache): a low level jmap-client library as well as a higher level jmap-mua library.
-* **[melib](https://meli.delivery)** (Rust): mail client library used in *meli* (GPLv3)
+* **[jmap-client-ts](https://github.com/OpenPaaS-Suite/jmap-client-ts)** (TypeScript, MIT): a lightweight promise-based API to make JMAP requests.
+* **[jmap-client](https://github.com/stalwartlabs/jmap-client)** (Rust; Apache/MIT): JMAP client library written in Rust. Includes full support for JMAP Core, JMAP Mail and JMAP over WebSocket.
+* **[JMAP-JS](https://github.com/jmapio/jmap-js)** (JavaScript, MIT): a full implementation of the JMAP mail, calendar and contacts model in JavaScript. It supports asynchronous local changes and is tolerant of network failure – actions will update the UI instantly, then synchronise changes back to the server when it can. It also has multi-level undo/redo support. Used by the [demo webmail](https://github.com/jmapio/jmap-demo-webmail).
 * **[jmap-rs](https://gitlab.com/jmap-rs/jmap-rs)** (Rust; in development): Rust client (and maybe server) library for JMAP
 * **[jmapc](https://pypi.org/project/jmapc/)** (Python; [partially implemented](https://github.com/smkent/jmapc)): Python 3 client library for JMAP mail
-* **[jmap-client](https://github.com/stalwartlabs/jmap-client)** (Rust; Apache/MIT): JMAP client library written in Rust. Includes full support for JMAP Core, JMAP Mail and JMAP over WebSocket.
-* **[go-jmap](https://sr.ht/~rockorager/go-jmap)** (Go, MIT): JMAP client library written in Go
+* **[melib](https://meli.delivery)** (Rust): mail client library used in *meli* (GPLv3)
+* **[zend-jmap](https://github.com/WikiSuite/zend-jmap)** (PHP, New BSD): JMAP for Zend Framework
 
 ## Proxies
 * **[Stalwart IMAP-to-JMAP Proxy](https://github.com/stalwartlabs/imap-to-jmap/)** (Rust, AGPLv3): Open-source IMAP4-to-JMAP proxy. Supports IMAP4rev2, IMAP4rev1 and multiple extensions.
@@ -46,15 +46,15 @@
 
 ## Requested
 
-* [RainLoop Webmail](https://github.com/RainLoop/rainloop-webmail/issues/1378)
-* [Horde IMP Webmail](https://bugs.horde.org/ticket/14683)
-* [Thunderbird](https://bugzilla.mozilla.org/show_bug.cgi?id=1322991)
-* [Claws Mail](https://www.thewildbeast.co.uk/claws-mail/bugzilla/show_bug.cgi?id=4057)
-* [Mailu](https://github.com/Mailu/Mailu/issues/471)
-* [K-9 Mail](https://github.com/k9mail/k-9/issues/3272)
-* [Nextcloud](https://github.com/nextcloud/server/issues/17802)
-* [Geary](https://gitlab.gnome.org/GNOME/geary/-/issues/327)
-* [Evolution](https://gitlab.gnome.org/GNOME/evolution/-/issues/364)
 * [Alps Webmail](https://todo.sr.ht/~migadu/alps/174)
+* [Claws Mail](https://www.thewildbeast.co.uk/claws-mail/bugzilla/show_bug.cgi?id=4057)
+* [Evolution](https://gitlab.gnome.org/GNOME/evolution/-/issues/364)
+* [Geary](https://gitlab.gnome.org/GNOME/geary/-/issues/327)
+* [Horde IMP Webmail](https://bugs.horde.org/ticket/14683)
+* [K-9 Mail](https://github.com/k9mail/k-9/issues/3272)
+* [Mailu](https://github.com/Mailu/Mailu/issues/471)
+* [Nextcloud](https://github.com/nextcloud/server/issues/17802)
+* [RainLoop Webmail](https://github.com/RainLoop/rainloop-webmail/issues/1378)
+* [Thunderbird](https://bugzilla.mozilla.org/show_bug.cgi?id=1322991)
 
 If you're working on a project that uses JMAP, please [open an issue](https://github.com/jmapio/jmap/issues) or make a [pull request](https://github.com/jmapio/jmap/pulls) on GitHub to update this page.

--- a/software/software.mdown
+++ b/software/software.mdown
@@ -29,6 +29,7 @@
 * **[Java JMAP Library](https://github.com/iNPUTmice/jmap)** (Java 7, Apache): a low level jmap-client library as well as a higher level jmap-mua library.
 * **[jmap-client-ts](https://github.com/OpenPaaS-Suite/jmap-client-ts)** (TypeScript, MIT): a lightweight promise-based API to make JMAP requests.
 * **[jmap-client](https://github.com/stalwartlabs/jmap-client)** (Rust; Apache/MIT): JMAP client library written in Rust. Includes full support for JMAP Core, JMAP Mail and JMAP over WebSocket.
+* **[jmap-jam](https://github.com/htunnicliff/jmap-jam)** (TypeScript, MIT): Jam is a tiny, strongly-typed JMAP client with zero runtime dependencies. It has friendly, fluent APIs that make working with JMAP a breeze.
 * **[JMAP-JS](https://github.com/jmapio/jmap-js)** (JavaScript, MIT): a full implementation of the JMAP mail, calendar and contacts model in JavaScript. It supports asynchronous local changes and is tolerant of network failure – actions will update the UI instantly, then synchronise changes back to the server when it can. It also has multi-level undo/redo support. Used by the [demo webmail](https://github.com/jmapio/jmap-demo-webmail).
 * **[jmap-rs](https://gitlab.com/jmap-rs/jmap-rs)** (Rust; in development): Rust client (and maybe server) library for JMAP
 * **[jmapc](https://pypi.org/project/jmapc/)** (Python; [partially implemented](https://github.com/smkent/jmapc)): Python 3 client library for JMAP mail


### PR DESCRIPTION
## Changes

- Sorted the contents of each software category list in alphabetical order.
- Added [`jmap-jam`](https://github.com/htunnicliff/jmap-jam) to the Libraries list. 