### PR TITLE
software/clients: add aerc

### DIFF
--- a/software/software.mdown
+++ b/software/software.mdown
@@ -2,6 +2,7 @@
 
 ## Clients
 
+* **[aerc](https://aerc-mail.org/)**: A terminal email client for the discerning hacker.
 * **[Cypht](https://github.com/jasonmunro/cypht/issues/180)**: lightweight Open Source webmail written in PHP and JavaScript.
 * **[Group-Office](https://github.com/Intermesh/groupoffice)** (Javascript): Open source groupware and collaboration platform
 * **[JMAP Demo Webmail](https://github.com/jmapio/jmap-demo-webmail)** (JavaScript, MIT): a sophisticated demo webmail client to be used as a base for new projects. Default client for the [proxy](https://proxy.jmap.io).


### PR DESCRIPTION
aerc supports JMAP since 0.16.0 (released on 2023-09-27).

https://git.sr.ht/~rjarry/aerc/refs/0.16.0