### PR TITLE
Remove dead proxy.jmap.io link

### DIFF
--- a/software/software.mdown
+++ b/software/software.mdown
@@ -21,7 +21,7 @@
 * **[Cyrus IMAP](https://www.cyrusimap.org/imap/download/release-notes/3.0/x/3.0.3.html)** (C, BSD-style): A scalable enterprise-grade IMAP, CalDAV and CardDAV server. The 3.0 series is adding JMAP support, instructions to enable it are [here](https://www.cyrusimap.org/dev/imap/developer/jmap.html).
 * **[Group-Office](https://github.com/Intermesh/groupoffice)** (PHP): Open source groupware and collaboration platform
 * **[hyper-auth-proxy](https://crates.io/crates/hyper-auth-proxy)** (Rust): A proxy to do HTTP basic auth from a JWT token and redis session credentials; build to add JWT bearer auth support to Cyrus's JMAP.
-* **[JMAP Proxy](https://github.com/jmapio/jmap-perl)** (Perl, MIT): a complete JMAP server implementation that uses any IMAP, CalDAV and CardDAV store as a backend. Also available as a hosted service at [proxy.jmap.io](https://proxy.jmap.io).
+* **[JMAP Proxy](https://github.com/jmapio/jmap-perl)** (Perl, MIT): a complete JMAP server implementation that uses any IMAP, CalDAV and CardDAV store as a backend.
 * **[Stalwart JMAP](https://github.com/stalwartlabs/jmap-server/)** (Rust, AGPLv3): Open-source JMAP server designed to be robust, secure and scalable. Includes full support for JMAP Core, JMAP Mail, JMAP for Sieve, JMAP over WebSocket, JMAP for Quotas and JMAP Blob Management.
 * **[tmail-backend](https://github.com/linagora/tmail-backend)** (Java, Apache): builds on Apache James with extra features
 


### PR DESCRIPTION
This subdomain is completely gone now and seems to have been some kind of broken since at least 2020; see jmapio/jmap-perl#58