### PR TITLE
Remove dovecot from planned list

### DIFF
--- a/software/software.mdown
+++ b/software/software.mdown
@@ -45,7 +45,6 @@
 
 ## Planned
 
-* [Dovecot](https://dovecot.org/pipermail/dovecot/2016-November/106262.html)
 * [Mimestream](https://mimestream.com/), a native macOS email client
 * [Mailtemi](https://mailtemi.com), a native Android and macOS email clients.
 


### PR DESCRIPTION
It seems like it is not planned at all, as per this message:
https://dovecot.org/mailman3/hyperkitty/list/dovecot@dovecot.org/message/4FIXWCJGDHSGXXJZQ76B5K4HW7RHCRYQ/

Key quote:

> We have no plans to actually start working on JMAP itself, but nothing prevents outside contributions. It would likely be in a separate git repository anyway.

There might be more to the picture, I just did a bit of research, found this, and figured I'd submit a PR.