### PR TITLE
Updated URL to the Java JMAP library

### DIFF
--- a/software/software.mdown
+++ b/software/software.mdown
@@ -30,7 +30,7 @@
 ## Libraries
 
 * **[go-jmap](https://sr.ht/~rockorager/go-jmap)** (Go, MIT): JMAP client library written in Go
-* **[Java JMAP Library](https://github.com/iNPUTmice/jmap)** (Java 7, Apache): a low level jmap-client library as well as a higher level jmap-mua library.
+* **[Java JMAP Library](https://codeberg.org/iNPUTmice/jmap/)** (Java 7, Apache): a low level jmap-client library as well as a higher level jmap-mua library.
 * **[jmap-client-ts](https://github.com/OpenPaaS-Suite/jmap-client-ts)** (TypeScript, MIT): a lightweight promise-based API to make JMAP requests.
 * **[jmap-client](https://github.com/stalwartlabs/jmap-client)** (Rust; Apache/MIT): JMAP client library written in Rust. Includes full support for JMAP Core, JMAP Mail and JMAP over WebSocket.
 * **[jmap-jam](https://github.com/htunnicliff/jmap-jam)** (TypeScript, MIT): Jam is a tiny, strongly-typed JMAP client with zero runtime dependencies. It has friendly, fluent APIs that make working with JMAP a breeze.


### PR DESCRIPTION
iNPUTmice moved his repositories to codeberg.org, so the URL to his java
library changed
