### PR TITLE
fix(software): correct URL for stalwart

### DIFF
--- a/software/software.mdown
+++ b/software/software.mdown
@@ -24,7 +24,7 @@
 * **[Group-Office](https://github.com/Intermesh/groupoffice)** (PHP): Open source groupware and collaboration platform
 * **[hyper-auth-proxy](https://crates.io/crates/hyper-auth-proxy)** (Rust): A proxy to do HTTP basic auth from a JWT token and redis session credentials; build to add JWT bearer auth support to Cyrus's JMAP.
 * **[JMAP Proxy](https://github.com/jmapio/jmap-perl)** (Perl, MIT): a complete JMAP server implementation that uses any IMAP, CalDAV and CardDAV store as a backend.
-* **[Stalwart](https://github.com/stalwartlabs/stalwart)** (Rust, AGPLv3): All-in-one Mail & Collaboration server. Secure, scalable and fluent in every protocol (IMAP, JMAP, SMTP, CalDAV, CardDAV, WebDAV). Includes full support for JMAP Core, JMAP Mail, JMAP for Sieve, JMAP over WebSocket, JMAP for Quotas and JMAP Blob Management.
+* **[Stalwart](https://github.com/stalwartlabs/stalwart)** (Rust, AGPLv3): Open-source JMAP server designed to be robust, secure and scalable. Includes full support for JMAP Core, JMAP Mail, JMAP for Sieve, JMAP over WebSocket, JMAP for Quotas and JMAP Blob Management.
 * **[tmail-backend](https://github.com/linagora/tmail-backend)** (Java, Apache): builds on Apache James with extra features
 
 ## Libraries

--- a/software/software.mdown
+++ b/software/software.mdown
@@ -24,7 +24,7 @@
 * **[Group-Office](https://github.com/Intermesh/groupoffice)** (PHP): Open source groupware and collaboration platform
 * **[hyper-auth-proxy](https://crates.io/crates/hyper-auth-proxy)** (Rust): A proxy to do HTTP basic auth from a JWT token and redis session credentials; build to add JWT bearer auth support to Cyrus's JMAP.
 * **[JMAP Proxy](https://github.com/jmapio/jmap-perl)** (Perl, MIT): a complete JMAP server implementation that uses any IMAP, CalDAV and CardDAV store as a backend.
-* **[Stalwart JMAP](https://github.com/stalwartlabs/jmap-server/)** (Rust, AGPLv3): Open-source JMAP server designed to be robust, secure and scalable. Includes full support for JMAP Core, JMAP Mail, JMAP for Sieve, JMAP over WebSocket, JMAP for Quotas and JMAP Blob Management.
+* **[Stalwart](https://github.com/stalwartlabs/stalwart)** (Rust, AGPLv3): All-in-one Mail & Collaboration server. Secure, scalable and fluent in every protocol (IMAP, JMAP, SMTP, CalDAV, CardDAV, WebDAV). Includes full support for JMAP Core, JMAP Mail, JMAP for Sieve, JMAP over WebSocket, JMAP for Quotas and JMAP Blob Management.
 * **[tmail-backend](https://github.com/linagora/tmail-backend)** (Java, Apache): builds on Apache James with extra features
 
 ## Libraries


### PR DESCRIPTION
Or should we use the URL to the Website?
- https://stalw.art/ 
or directo to documentation:
- https://stalw.art/docs/
inside the documentation are multiple JMAP parts (and they are moving), e.g. (current state);
  - https://stalw.art/docs/http/jmap/overview
  - https://stalw.art/docs/email/jmap
  - https://stalw.art/docs/sieve/jmap/
