### PR TITLE
update RFC links in documentation

### DIFF
--- a/spec/calendars/alerts.mdown
+++ b/spec/calendars/alerts.mdown
@@ -1,6 +1,6 @@
 # Alerts
 
-Alerts may be specified on events as described in [@!RFC8984], Section 4.5.
+Alerts may be specified on events as described in [RFC8984](https://www.rfc-editor.org/rfc/rfc8984), Section 4.5.
 
 Alerts MUST only be triggered for events in calendars where the user is subscribed.
 
@@ -38,7 +38,7 @@ When acknowledging a snoozed alert (i.e. one with a parent relatedTo pointing to
 
 ## Push events
 
-Servers that support the `urn:ietf:params:jmap:calendars` capability MUST support registering for the pseudo-type "CalendarAlert" in push subscriptions and event source connections, as described in [@!RFC8620], Sections 7.2 and 7.3.
+Servers that support the `urn:ietf:params:jmap:calendars` capability MUST support registering for the pseudo-type "CalendarAlert" in push subscriptions and event source connections, as described in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Sections 7.2 and 7.3.
 
 If requested, a CalendarAlert notification will be pushed whenever an alert is triggered for the user. For Event Source connections, this notification is pushed as an event called "calendarAlert".
 

--- a/spec/calendars/calendar.mdown
+++ b/spec/calendars/calendar.mdown
@@ -47,22 +47,22 @@ A **Calendar** object has the following properties:
   Should the calendar's events be used as part of availability calculation?
   This MUST be one of:
 
-    - `all`: all events are considered.
-    - `attending`: events the user is a confirmed or tentative participant of
+  - `all`: all events are considered.
+  - `attending`: events the user is a confirmed or tentative participant of
       are considered.
-    - `none`: all events are ignored (but may be considered if also in another
+  - `none`: all events are ignored (but may be considered if also in another
       calendar).
 
     This should default to "all" for the calendars in the user's own account,
     and "none" for calendars shared with the user.
 
 - **defaultAlertsWithTime**: `Id[Alert]|null`
-  A map of alert ids to Alert objects (see [@!RFC8984], Section 4.5.2) to apply for events where "showWithoutTime" is false and "useDefaultAlerts" is true. Ids MUST be unique across all default alerts in the account, including those in other calendars; a UUID is recommended.
+  A map of alert ids to Alert objects (see [RFC8984](https://www.rfc-editor.org/rfc/rfc8984), Section 4.5.2) to apply for events where "showWithoutTime" is false and "useDefaultAlerts" is true. Ids MUST be unique across all default alerts in the account, including those in other calendars; a UUID is recommended.
 
     If omitted on creation, the default is server dependent. For example, servers may choose to always default to `null`, or may copy the alerts from the default calendar.
 
 - **defaultAlertsWithoutTime**: `Id[Alert]|null`
-  A map of alert ids to Alert objects (see [@!RFC8984], Section 4.5.2) to apply for events where "showWithoutTime" is true and "useDefaultAlerts" is true. Ids MUST be unique across all default alerts in the account, including those in other calendars; a UUID is recommended.
+  A map of alert ids to Alert objects (see [RFC8984](https://www.rfc-editor.org/rfc/rfc8984), Section 4.5.2) to apply for events where "showWithoutTime" is true and "useDefaultAlerts" is true. Ids MUST be unique across all default alerts in the account, including those in other calendars; a UUID is recommended.
 
     If omitted on creation, the default is server dependent. For example, servers may choose to always default to `null`, or may copy the alerts from the default calendar.
 
@@ -83,7 +83,6 @@ A **Calendar** object has the following properties:
   - The user may make other changes to the event if they have the right to do
     so in *all* calendars to which the event belongs.
 
-
 A **CalendarRights** object has the following properties:
 
 - **mayReadFreeBusy**: `Boolean`
@@ -102,12 +101,12 @@ A **CalendarRights** object has the following properties:
 - **mayRSVP**: `Boolean`
   The user may modify the following properties of any Participant object that corresponds to one of the user's ParticipantIdentity objects in the account, even if they would not otherwise have permission to modify that event:
 
-    - participationStatus
-    - participationComment
-    - expectReply
-    - scheduleAgent
-    - scheduleSequence
-    - scheduleUpdated
+  - participationStatus
+  - participationComment
+  - expectReply
+  - scheduleAgent
+  - scheduleSequence
+  - scheduleUpdated
 
     If the event has its "mayInviteSelf" property set to true (see Section XXX), then the user may also add a new Participant to the event with scheduleId/sendTo properties that are the same as the scheduleId/sendTo properties of one of the user's ParticipantIdentity objects in the account. The roles property of the participant MUST only contain "attendee".
 
@@ -129,17 +128,17 @@ An event has no owner if its participants property is null or omitted, or if non
 
 ## Calendar/get
 
-This is a standard "/get" method as described in [@!RFC8620], Section 5.1. The *ids* argument may be `null` to fetch all at once.
+This is a standard "/get" method as described in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 5.1. The *ids* argument may be `null` to fetch all at once.
 
 If mayReadFreeBusy is the only permission the user has, the calendar MUST NOT be returned in Calendar/get and Calendar/query; it must behave as though it did not exist. The data is just used as part of Principal/getAvailability.
 
 ## Calendar/changes
 
-This is a standard "/changes" method as described in [@!RFC8620], Section 5.2.
+This is a standard "/changes" method as described in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 5.2.
 
 ## Calendar/set
 
-This is a standard "/set" method as described in [@!RFC8620], Section 5.3 but with the following additional request arguments:
+This is a standard "/set" method as described in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 5.3 but with the following additional request arguments:
 
 - **onDestroyRemoveEvents**: `Boolean` (default: false)
 
@@ -157,7 +156,7 @@ This is a standard "/set" method as described in [@!RFC8620], Section 5.3 but wi
   policy reasons, it MUST be ignored and the currently default calendar (if
   any) will remain as such. No error is returned to the client in this case.
 
-  As per [@!RFC8620], Section 5.3, if the default is successfully changed, any
+  As per [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 5.3, if the default is successfully changed, any
   changed objects MUST be reported in either the "created" or "updated"
   argument in the response as  appropriate, with the server-set value included.
 

--- a/spec/calendars/event.mdown
+++ b/spec/calendars/event.mdown
@@ -1,6 +1,6 @@
 # Calendar Events
 
-A **CalendarEvent** object contains information about an event, or recurring series of events, that takes place at a particular time. It is a JSCalendar Event object, as defined in [@!RFC8984], with the following additional properties:
+A **CalendarEvent** object contains information about an event, or recurring series of events, that takes place at a particular time. It is a JSCalendar Event object, as defined in [RFC8984](https://www.rfc-editor.org/rfc/rfc8984), with the following additional properties:
 
 - **id**: `Id` (immutable; server-set)
   The id of the CalendarEvent. The id uniquely identifies a JSCalendar Event with a particular "uid" and "recurrenceId" within a particular account.
@@ -19,8 +19,8 @@ A **CalendarEvent** object contains information about an event, or recurring ser
   scheduling for this event; the event has not been added as a result of an
   invitation from another calendar system)? This is true if, and only if:
 
-    * the event's "replyTo" property is `null`; or
-    * the account will receive messages sent to at least one of the methods
+  - the event's "replyTo" property is `null`; or
+  - the account will receive messages sent to at least one of the methods
       specified in the "replyTo" property of the event.
 
 - **utcStart**: `UTCDate`
@@ -39,7 +39,7 @@ A **CalendarEvent** object contains information about an event, or recurring ser
 - **utcEnd**: `UTCDate`
   The server calculates the end time in UTC from the start/timeZone/duration properties of the event. This property is not included by default and must be requested explicitly. Like utcStart, it is calculated at fetch time if requested and may change due to time zone data changes. Floating events will be interpreted as per the time zone given as a CalendarEvent/get argument.
 
-CalendarEvent objects MUST NOT have a "method" property as this is only used when representing iTIP [@!RFC5546] scheduling messages, not events in a data store.
+CalendarEvent objects MUST NOT have a "method" property as this is only used when representing iTIP [RFC5546](https://www.rfc-editor.org/rfc/rfc5546) scheduling messages, not events in a data store.
 
 ## Additional JSCalendar properties
 
@@ -51,7 +51,7 @@ Type: `String`
 
 Context: Participant
 
-This is a URI as defined by [@!RFC3986] or any other IANA-registered form for a URI. It is the same as the CAL-ADDRESS value of an ATTENDEE or ORGANIZER in iCalendar ([@!RFC5545]) — it globally identifies a particular participant, even across different events.
+This is a URI as defined by [RFC3986](https://www.rfc-editor.org/rfc/rfc3986) or any other IANA-registered form for a URI. It is the same as the CAL-ADDRESS value of an ATTENDEE or ORGANIZER in iCalendar ([RFC5545](https://www.rfc-editor.org/rfc/rfc5545)) — it globally identifies a particular participant, even across different events.
 
 ### mayInviteSelf
 
@@ -83,9 +83,9 @@ If true, only the owners of the event may see the full set of participants. Othe
 
 ## Attachments
 
-The Link object, as defined in [@!RFC8984] Section 4.2.7, with a "rel" property equal to "enclosure" is used to represent attachments. Instead of mandating an "href" property, clients may set a "blobId" property instead to reference a blob of binary data in the account, as per [@!RFC8620] Section 6.
+The Link object, as defined in [RFC8984](https://www.rfc-editor.org/rfc/rfc8984) Section 4.2.7, with a "rel" property equal to "enclosure" is used to represent attachments. Instead of mandating an "href" property, clients may set a "blobId" property instead to reference a blob of binary data in the account, as per [RFC8620](https://www.rfc-editor.org/rfc/rfc8620) Section 6.
 
-The server MUST translate this to an embedded `data:` URL [@!RFC2397] when sending the event to a system that cannot access the blob. Servers that support CalDAV access to the same data are recommended to expose these files as managed attachments [?@RFC8607].
+The server MUST translate this to an embedded `data:` URL [RFC2397](https://www.rfc-editor.org/rfc/rfc2397) when sending the event to a system that cannot access the blob. Servers that support CalDAV access to the same data are recommended to expose these files as managed attachments [?@RFC8607].
 
 ## Per-user properties
 
@@ -115,7 +115,7 @@ When editing a recurring event, you can either update the base event (affecting 
 
 ### Splitting an event
 
-If the event is not scheduled (has no participants), the simplest thing to do is to duplicate the event, modifying the recurrence rules of the original so it finishes before the split point, and the duplicate so it starts at the split point. As per JSCalendar [@!RFC8984] Section 4.1.3, a "next" and "first" relation MUST be set on the new objects respectively.
+If the event is not scheduled (has no participants), the simplest thing to do is to duplicate the event, modifying the recurrence rules of the original so it finishes before the split point, and the duplicate so it starts at the split point. As per JSCalendar [RFC8984](https://www.rfc-editor.org/rfc/rfc8984) Section 4.1.3, a "next" and "first" relation MUST be set on the new objects respectively.
 
 Splitting an event however is problematic in the case of a scheduled event, because the iTIP messages generated make it appear like two unrelated changes, which can be confusing.
 
@@ -127,7 +127,7 @@ Clients may choose to skip creating the overrides if the old data is not importa
 
 ## CalendarEvent/get
 
-This is a standard "/get" method as described in [@!RFC8620], Section 5.1, with three extra arguments:
+This is a standard "/get" method as described in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 5.1, with three extra arguments:
 
 - **recurrenceOverridesBefore**: `UTCDate|null`
   If given, only recurrence overrides with a recurrence id before this date (when translated into UTC) will be returned.
@@ -150,24 +150,24 @@ The "hideAttendees" property of a JSCalendar Event object allows the event owner
 
 The "privacy" property of a JSCalendar Event object allows the principal that owns the calendar to override how sharees of the calendar see the event. If set to "private", then when a sharee fetches the event the server MUST only return properties that are:
 
-* the basic time and metadata properties of the JSCalendar Event object as specified in
-  [@!RFC8984], Section 4.4.3; or
-* properties that are wholly derived from these permitted properties
+- the basic time and metadata properties of the JSCalendar Event object as specified in
+  [RFC8984](https://www.rfc-editor.org/rfc/rfc8984), Section 4.4.3; or
+- properties that are wholly derived from these permitted properties
   (i.e., utcStart, utcEnd); or
-* Additional CalendarEvent properties not derived from the JSCalendar Event data
+- Additional CalendarEvent properties not derived from the JSCalendar Event data
   (i.e., id, baseEventId, calendarIds, isDraft, isOrigin).
 
 If "privacy" is set to "secret", the server MUST behave as though the event does not exist for all users other than the principal that owns the calendar.
 
 ## CalendarEvent/changes
 
-This is a standard "/changes" method as described in [@!RFC8620], Section 5.2.
+This is a standard "/changes" method as described in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 5.2.
 
 Synthetic ids generated by the server expanding recurrences in "CalendarEvent/query" do not appear in "CalendarEvent/changes" responses; only the ids of events as actually stored on the server.
 
 ## CalendarEvent/set
 
-This is a standard "/set" method as described in [@!RFC8620], Section 5.3, with the following extra argument:
+This is a standard "/set" method as described in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 5.3, with the following extra argument:
 
 - **sendSchedulingMessages**: `Boolean` (default: false)
   If true then any changes to scheduled events will be sent to all the participants (if the server is the origin of the event) or back to the origin (otherwise). If false, the changes only affect this account and no scheduling messages will be sent.
@@ -198,10 +198,10 @@ properties when the "isOrigin" property is false, even if the calendar "myRights
 
 When updating an event, if all of:
 
-* a property has been changed other than "calendarIds", "isDraft", "updated" or
+- a property has been changed other than "calendarIds", "isDraft", "updated" or
   a per-user property (see Section XXX); and
-* the server is the origin of the event (the "isOrigin" property is true); and
-* the "sequence" property is not explicitly set in the update, or the given
+- the server is the origin of the event (the "isOrigin" property is true); and
+- the "sequence" property is not explicitly set in the update, or the given
   value is less than or equal to the current "sequence" value on the server;
 
 then the server MUST increment the "sequence" value by one.
@@ -341,10 +341,9 @@ This would mean remove the "participants/dG9tQGZvb2Jhci5xlLmNvbQ" property at pa
       }
     }, "0" ]]
 
-
 ### Sending invitations and responses
 
-If "sendSchedulingMessages" is true, the server MUST send appropriate iTIP [@!RFC5546] scheduling messages after successfuly creating, updating or destroying a calendar event.
+If "sendSchedulingMessages" is true, the server MUST send appropriate iTIP [RFC5546](https://www.rfc-editor.org/rfc/rfc5546) scheduling messages after successfuly creating, updating or destroying a calendar event.
 
 When determining which scheduling messages to send, the server must first establish whether it is the *origin* of the event, as described in the "isOrigin" property.
 
@@ -364,13 +363,13 @@ If sending via iMIP [@?RFC6047], the server MAY choose to only send updates it d
 
 #### REQUEST
 
-When the server is the origin for the event, a REQUEST message ([@!RFC5546], Section 3.2.2) is sent to all current participants (except those corresponding to the owner of the calendar) if either:
+When the server is the origin for the event, a REQUEST message ([RFC5546](https://www.rfc-editor.org/rfc/rfc5546), Section 3.2.2) is sent to all current participants (except those corresponding to the owner of the calendar) if either:
 
 - The event is being created; or
 - Any non per-user property (see Section XXX) is updated on the event
   (including adding/removing participants), except if just modifying the recurrenceOverrides such that CANCEL messages are generated (see the next section).
 
-Note, if the only change is adding an additional instance (not generated by the event's recurrence rule) to the recurrenceOverrides, this MAY be handled via sending an ADD message ([@!RFC5546], Section 3.2.4) for the single instance rather than a REQUEST message for the base event. However, for interoperability reasons this is not recommended due to poor support in the wild for this type of message.
+Note, if the only change is adding an additional instance (not generated by the event's recurrence rule) to the recurrenceOverrides, this MAY be handled via sending an ADD message ([RFC5546](https://www.rfc-editor.org/rfc/rfc5546), Section 3.2.4) for the single instance rather than a REQUEST message for the base event. However, for interoperability reasons this is not recommended due to poor support in the wild for this type of message.
 
 The server MUST ensure participants are only sent information about recurrence instances they are added to when sending scheduling messages for recurring events. If the participant is not invited to the full recurring event but only individual instances, scheduling messages MUST be sent for just those expanded occurrences individually. If a participant is invited to a recurring event, but removed via a recurrence override from a particular instance, any scheduling messages to this participant MUST return the instance as "excluded" (if it matches a recurrence rule for the event) or omit the instance entirely (otherwise).
 
@@ -378,7 +377,7 @@ If the event's "hideAttendees" property is set to true, the recipient MUST be th
 
 #### CANCEL
 
-When the server is the origin for the event, a CANCEL message ([@!RFC5546], Section 3.2.5) is sent if any of:
+When the server is the origin for the event, a CANCEL message ([RFC5546](https://www.rfc-editor.org/rfc/rfc5546), Section 3.2.5) is sent if any of:
 
 - A participant is removed from either the base event or a single instance
   (the message is only sent to this participant; remaining participants will get a REQUEST, as described above).
@@ -392,7 +391,7 @@ In each of the latter 3 cases, the message is sent to all participants (except t
 
 #### REPLY
 
-When the server is *not* the origin for the event, a REPLY message ([@!RFC5546], Section 3.2.3) is sent for every participant corresponding to one of the user's ParticipantIdentitities in the account if any of the following changes are made:
+When the server is *not* the origin for the event, a REPLY message ([RFC5546](https://www.rfc-editor.org/rfc/rfc5546), Section 3.2.3) is sent for every participant corresponding to one of the user's ParticipantIdentitities in the account if any of the following changes are made:
 
 - The "participationStatus" property of the participant is changed, either for
   the base event or a specific instance, to any value other than "needs-action".
@@ -403,11 +402,11 @@ If the participationStatus property is changed for just a single instance of the
 
 ## CalendarEvent/copy
 
-This is a standard "/copy" method as described in [@!RFC8620], Section 5.4.
+This is a standard "/copy" method as described in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 5.4.
 
 ## CalendarEvent/query
 
-This is a standard "/query" method as described in [@!RFC8620], Section 5.5, with two extra arguments:
+This is a standard "/query" method as described in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 5.5, with two extra arguments:
 
 - **expandRecurrences**: `Boolean` (default: false)
   If true, the server will expand any recurring event. If true, the filter MUST be just a FilterCondition (not a FilterOperator) and MUST include both a "before" and "after" property. This ensures the server is not asked to return an infinite number of results.
@@ -475,11 +474,11 @@ The following properties SHOULD be supported for sorting:
 
 ## CalendarEvent/queryChanges
 
-This is a standard "/queryChanges" method as described in [@!RFC8620], Section 5.6.
+This is a standard "/queryChanges" method as described in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 5.6.
 
 ## CalendarEvent/parse
 
-This method allows the client to parse blobs as `iCalendar` files [@!RFC5545] to get `CalendarEvent` objects. This can be used to parse, display, and import information from iCalendar files without having to implement iCalendar parsing in the client. Server support for this is optional, and indicated via the "urn:ietf:params:jmap:calendars:parse" capability, as per Section XXX.
+This method allows the client to parse blobs as `iCalendar` files [RFC5545](https://www.rfc-editor.org/rfc/rfc5545) to get `CalendarEvent` objects. This can be used to parse, display, and import information from iCalendar files without having to implement iCalendar parsing in the client. Server support for this is optional, and indicated via the "urn:ietf:params:jmap:calendars:parse" capability, as per Section XXX.
 
 The following metadata properties on the CalendarEvent objects will be `null` if requested:
 

--- a/spec/calendars/eventnotifications.mdown
+++ b/spec/calendars/eventnotifications.mdown
@@ -55,22 +55,22 @@ If the change only affects a single instance of a recurring event, the server MA
 
 ## CalendarEventNotification/get
 
-This is a standard "/get" method as described in [@!RFC8620], Section 5.1.
+This is a standard "/get" method as described in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 5.1.
 
 ## CalendarEventNotification/changes
 
-This is a standard "/changes" method as described in [@!RFC8620], Section 5.2.
+This is a standard "/changes" method as described in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 5.2.
 
 ## CalendarEventNotification/set
 
-This is a standard "/set" method as described in [@!RFC8620], Section 5.3.
+This is a standard "/set" method as described in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 5.3.
 
 Only destroy is supported; any attempt to create/update MUST be rejected with a
 `forbidden` SetError.
 
 ## CalendarEventNotification/query
 
-This is a standard "/query" method as described in [@!RFC8620], Section 5.5.
+This is a standard "/query" method as described in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 5.5.
 
 ### Filtering
 
@@ -91,5 +91,4 @@ The "created" property MUST be supported for sorting.
 
 ## CalendarEventNotification/queryChanges
 
-This is a standard "/queryChanges" method as described in [@!RFC8620], Section 5.6.
-
+This is a standard "/queryChanges" method as described in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 5.6.

--- a/spec/calendars/intro.mdown
+++ b/spec/calendars/intro.mdown
@@ -1,34 +1,34 @@
 # Introduction
 
-JMAP ([@!RFC8620] – JSON Meta Application Protocol) is a generic protocol for synchronizing data, such as mail, calendars or contacts, between a client and a server. It is optimized for mobile and web environments, and aims to provide a consistent interface to different data types.
+JMAP ([RFC8620](https://www.rfc-editor.org/rfc/rfc8620) – JSON Meta Application Protocol) is a generic protocol for synchronizing data, such as mail, calendars or contacts, between a client and a server. It is optimized for mobile and web environments, and aims to provide a consistent interface to different data types.
 
 This specification defines a data model for synchronizing calendar data between a client and a server using JMAP. The data model is designed to allow a server to provide consistent access to the same data via CalDAV [@?RFC4791] as well as JMAP, however the functionality offered over the two protocols may differ. Unlike CalDAV, this specification does not define access to tasks or journal entries (VTODO or VJOURNAL iCalendar components in CalDAV).
 
 ## Notational Conventions
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in BCP 14 [@!RFC2119] [@!RFC8174] when, and only when, they appear in all capitals, as shown here.
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in BCP 14 [RFC2119](https://www.rfc-editor.org/rfc/rfc2119) [RFC8174](https://www.rfc-editor.org/rfc/rfc8174) when, and only when, they appear in all capitals, as shown here.
 
-Type signatures, examples, and property descriptions in this document follow the conventions established in Section 1.1 of [@!RFC8620].  Data types defined in the core specification are also used in this document.
+Type signatures, examples, and property descriptions in this document follow the conventions established in Section 1.1 of [RFC8620](https://www.rfc-editor.org/rfc/rfc8620).  Data types defined in the core specification are also used in this document.
 
 ## The LocalDate Data Type
 
-Where `LocalDate` is given as a type, it means a string in the same format as `Date` (see [@!RFC8620], Section 1.4), but with the `time-offset` omitted from the end. For example, `2014-10-30T14:12:00`. The interpretation in absolute time depends upon the time zone for the event, which may not be a fixed offset (for example when daylight saving time occurs).
+Where `LocalDate` is given as a type, it means a string in the same format as `Date` (see [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 1.4), but with the `time-offset` omitted from the end. For example, `2014-10-30T14:12:00`. The interpretation in absolute time depends upon the time zone for the event, which may not be a fixed offset (for example when daylight saving time occurs).
 
 ## The Duration Data Type
 
-Where `Duration` is given as a type, it means a length of time represented by a subset of the ISO 8601 duration format, as defined in [@!RFC8984], Section 1.4.6.
+Where `Duration` is given as a type, it means a length of time represented by a subset of the ISO 8601 duration format, as defined in [RFC8984](https://www.rfc-editor.org/rfc/rfc8984), Section 1.4.6.
 
 ## Terminology
 
-The same terminology is used in this document as in the core JMAP specification, see [@!RFC8620], Section 1.6.
+The same terminology is used in this document as in the core JMAP specification, see [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 1.6.
 
 The terms ParticipantIdentity, Calendar, CalendarEvent, and CalendarEventNotification (with these specific capitalizations) are used to refer to the data types defined in this document and instances of those data types.
 
 ## Data Model Overview
 
-An Account (see [@!RFC8620], Section 1.6.2) with support for the calendar data model contains zero or more Calendar objects, which is a named collection of CalendarEvents. Calendars can also provide defaults, such as alerts and a color to apply to events in the calendar. Clients commonly let users toggle visibility of events belonging to a particular calendar on/off. Servers may allow an event to belong to multiple Calendars within an account.
+An Account (see [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 1.6.2) with support for the calendar data model contains zero or more Calendar objects, which is a named collection of CalendarEvents. Calendars can also provide defaults, such as alerts and a color to apply to events in the calendar. Clients commonly let users toggle visibility of events belonging to a particular calendar on/off. Servers may allow an event to belong to multiple Calendars within an account.
 
-A CalendarEvent is a representation of an event or recurring series of events in JSCalendar Event [@!RFC8984] format. Simple clients may ask the server to expand recurrences for them within a specific time period, and optionally convert times into UTC so they do not have to handle time zone conversion. More full-featured clients will want to access the full event information and handle recurrence expansion and time zone conversion locally.
+A CalendarEvent is a representation of an event or recurring series of events in JSCalendar Event [RFC8984](https://www.rfc-editor.org/rfc/rfc8984) format. Simple clients may ask the server to expand recurrences for them within a specific time period, and optionally convert times into UTC so they do not have to handle time zone conversion. More full-featured clients will want to access the full event information and handle recurrence expansion and time zone conversion locally.
 
 CalendarEventNotification objects keep track of the history of changes made to a calendar by other users, allowing calendar clients to notify the user of changes to their schedule.
 
@@ -40,7 +40,7 @@ Users can normally subscribe to any calendar to which they have access. This ind
 
 ### UIDs and CalendarEvent Ids
 
-Each CalendarEvent has a `uid` property ([@!RFC8984], Section 4.1.2), which is a globally unique identifier that identifies the same event in different Accounts, or different instances of the same recurring event within an Account.
+Each CalendarEvent has a `uid` property ([RFC8984](https://www.rfc-editor.org/rfc/rfc8984), Section 4.1.2), which is a globally unique identifier that identifies the same event in different Accounts, or different instances of the same recurring event within an Account.
 
 An Account MUST NOT contain more than one CalendarEvent with the same uid unless all of the CalendarEvent objects have distinct, non-null values for their `recurrenceId` property. (This situation occurs if the principal is added to one or more specific instances of a recurring event without being invited to the whole series.)
 
@@ -48,7 +48,7 @@ Each CalendarEvent also has an id, which is scoped to the JMAP Account and used 
 
 ## Addition to the Capabilities Object
 
-The capabilities object is returned as part of the JMAP Session object; see [@!RFC8620], Section 2. This document defines three additional capability URIs.
+The capabilities object is returned as part of the JMAP Session object; see [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 2. This document defines three additional capability URIs.
 
 ### urn:ietf:params:jmap:calendars
 

--- a/spec/calendars/participantidentity.mdown
+++ b/spec/calendars/participantidentity.mdown
@@ -25,21 +25,21 @@ A ParticipantIdentity stores information about a URI that represents the user wi
   feature to allow users to choose which identity to use based on the
   invitees.)
 
-A participant in an event corresponds to a ParticipantIdentity if the scheduleId property of the participant is equivalent to the scheduleId property of the identity after syntax-based normalisation, as per [@!RFC3986], Section 6.2.2.
+A participant in an event corresponds to a ParticipantIdentity if the scheduleId property of the participant is equivalent to the scheduleId property of the identity after syntax-based normalisation, as per [RFC3986](https://www.rfc-editor.org/rfc/rfc3986), Section 6.2.2.
 
 The following JMAP methods are supported.
 
 ## ParticipantIdentity/get
 
-This is a standard "/get" method as described in [@!RFC8620], Section 5.1. The *ids* argument may be `null` to fetch all at once.
+This is a standard "/get" method as described in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 5.1. The *ids* argument may be `null` to fetch all at once.
 
 ## ParticipantIdentity/changes
 
-This is a standard "/changes" method as described in [@!RFC8620], Section 5.2.
+This is a standard "/changes" method as described in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 5.2.
 
 ## ParticipantIdentity/set
 
-This is a standard "/set" method as described in [@!RFC8620], Section 5.3, but with the following additional request argument:
+This is a standard "/set" method as described in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 5.3, but with the following additional request argument:
 
 - **onSuccessSetIsDefault**: `Id|null`
   If an id is given, and all creates, updates and destroys (if any) succeed
@@ -52,9 +52,8 @@ This is a standard "/set" method as described in [@!RFC8620], Section 5.3, but w
   ParticipantIdentity (if any) will remain as such. No error is returned to
   the client in this case.
 
-  As per [@!RFC8620], Section 5.3, if the default is successfully changed, any
+  As per [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 5.3, if the default is successfully changed, any
   changed objects MUST be reported in either the "created" or "updated"
   argument in the response as  appropriate, with the server-set value included.
-
 
 The server MAY restrict the uri values the user may claim, for example only allowing `mailto:` URIs with email addresses that belong to the user. A standard `forbidden` error is returned to reject non-permissible changes.

--- a/spec/calendars/principal.mdown
+++ b/spec/calendars/principal.mdown
@@ -17,7 +17,7 @@ A "urn:ietf:params:jmap:calendars" property is added to the Principal "capabilit
 - **scheduleId**: `String`
   If this principal may be added as a participant to an event, this is the scheduleId to use to represent it.
 - **sendTo**: `String[String]|null`
-  If this principal may be added as a participant to an event, this is the Participant#sendTo property to add (see [@!RFC8984], Section 4.4.5) for scheduling messages to reach it.
+  If this principal may be added as a participant to an event, this is the Participant#sendTo property to add (see [RFC8984](https://www.rfc-editor.org/rfc/rfc8984), Section 4.4.5) for scheduling messages to reach it.
 
 ## Principal/getAvailability
 
@@ -70,9 +70,9 @@ The server then generates a BusyPeriod object for each of these events. A **Busy
 - **event**: `JSCalendar Event|null`
   The JSCalendar Event representation of the event, or null if any of the following are true:
 
-    - The "showDetails" argument is false.
-    - The "privacy" property of the event is "private".
-    - The user does not have the "mayReadItems" permission for any of the
+  - The "showDetails" argument is false.
+  - The "privacy" property of the event is "private".
+  - The user does not have the "mayReadItems" permission for any of the
       calendars the event is in.
 
     If an eventProperties argument was given, any properties in the JSCalendar Event that are not in the eventProperties list are removed from the returned representation.

--- a/spec/calendars/securityconsiderations.mdown
+++ b/spec/calendars/securityconsiderations.mdown
@@ -1,20 +1,20 @@
 # Security Considerations
 
-All security considerations of JMAP [@!RFC8620] and JSCalendar [@!RFC8984] apply to this specification. Additional considerations specific to the data types and functionality introduced by this document are described in the following subsections.
+All security considerations of JMAP [RFC8620](https://www.rfc-editor.org/rfc/rfc8620) and JSCalendar [RFC8984](https://www.rfc-editor.org/rfc/rfc8984) apply to this specification. Additional considerations specific to the data types and functionality introduced by this document are described in the following subsections.
 
 ## Privacy
 
 Calendars often contain the precise movements, activities, and contacts of people; all intensely private data. Privacy leaks can have real world consequences, and calendar servers and clients MUST be mindful of the need to keep all data secure.
 
-Servers MUST enforce the ACLs set on calendars to ensure only authorised data is shared. The additional restrictions specified by the "privacy" property of a JSCalendar Event object (see [@!RFC8984] Section 4.4.3) MUST also be enforced.
+Servers MUST enforce the ACLs set on calendars to ensure only authorised data is shared. The additional restrictions specified by the "privacy" property of a JSCalendar Event object (see [RFC8984](https://www.rfc-editor.org/rfc/rfc8984) Section 4.4.3) MUST also be enforced.
 
-Users may have multiple Participant Identities that they use for areas of their life kept private from one another. Using one identity with an event MUST NOT leak the existence of any other identity. For example, sending an RSVP from identity worklife@example.com MUST NOT reveal anything about another identity present in the account such as privatelife@example.org.
+Users may have multiple Participant Identities that they use for areas of their life kept private from one another. Using one identity with an event MUST NOT leak the existence of any other identity. For example, sending an RSVP from identity <worklife@example.com> MUST NOT reveal anything about another identity present in the account such as <privatelife@example.org>.
 
 Severs SHOULD enforce that invitations sent to external systems are only transmitted via secure encrypted and signed connections to protect against eavesdropping and modification of data.
 
 ## Spoofing
 
-When receiving events and updates from external systems, it can be hard to verify that the identity of the author is who they claim to be. When receiving events via email, DKIM [@!RFC6376] and S/MIME [@!RFC8551] are two mechanisms that may be used to verify certain properties about the email data, which can be correlated with the event information.
+When receiving events and updates from external systems, it can be hard to verify that the identity of the author is who they claim to be. When receiving events via email, DKIM [RFC6376](https://www.rfc-editor.org/rfc/rfc6376) and S/MIME [RFC8551](https://www.rfc-editor.org/rfc/rfc8551) are two mechanisms that may be used to verify certain properties about the email data, which can be correlated with the event information.
 
 ## Denial-of-service
 

--- a/spec/contacts/addressbook.mdown
+++ b/spec/contacts/addressbook.mdown
@@ -46,18 +46,17 @@ An **AddressBookRights** object has the following properties:
 - **mayDelete**: `Boolean`
   The user may delete the AddressBook itself.
 
-
 ## AddressBook/get
 
-This is a standard "/get" method as described in [@!RFC8620], Section 5.1. The *ids* argument may be `null` to fetch all at once.
+This is a standard "/get" method as described in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 5.1. The *ids* argument may be `null` to fetch all at once.
 
 ## AddressBook/changes
 
-This is a standard "/changes" method as described in [@!RFC8620], Section 5.2.
+This is a standard "/changes" method as described in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 5.2.
 
 ## AddressBook/set
 
-This is a standard "/set" method as described in [@!RFC8620], Section 5.3 but with the following additional request argument:
+This is a standard "/set" method as described in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 5.3 but with the following additional request argument:
 
 - **onDestroyRemoveContents**: `Boolean` (default: false)
   If false, any attempt to destroy an AddressBook that still has ContactCard
@@ -74,7 +73,7 @@ This is a standard "/set" method as described in [@!RFC8620], Section 5.3 but wi
   policy reasons, it MUST be ignored and the currently default AddressBook (if
   any) will remain as such. No error is returned to the client in this case.
 
-  As per [@!RFC8620], Section 5.3, if the default is successfully changed, any
+  As per [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 5.3, if the default is successfully changed, any
   changed objects MUST be reported in either the "created" or "updated"
   argument in the response as  appropriate, with the server-set value included.
 

--- a/spec/contacts/card.mdown
+++ b/spec/contacts/card.mdown
@@ -18,15 +18,15 @@ A contact card with a "kind" property equal to "group" represents a group of con
 
 ## ContactCard/get
 
-This is a standard "/get" method as described in [@!RFC8620], Section 5.1.
+This is a standard "/get" method as described in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 5.1.
 
 ## ContactCard/changes
 
-This is a standard "/changes" method as described in [@!RFC8620], Section 5.2.
+This is a standard "/changes" method as described in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 5.2.
 
 ## ContactCard/query
 
-This is a standard "/query" method as described in [@!RFC8620], Section 5.5.
+This is a standard "/query" method as described in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 5.5.
 
 ### Filtering
 
@@ -73,7 +73,6 @@ A **FilterCondition** object has the following properties, any of which may be o
 - **note**: `String`
   A card matches this condition if the "note" of any Note in the "notes" property of the card matches the value.
 
-
 If zero properties are specified on the FilterCondition, the condition MUST always evaluate to `true`. If multiple properties are specified, ALL must apply for the condition to be `true` (it is equivalent to splitting the object into one-property conditions and making them all the child of an AND filter operator).
 
 The exact semantics for matching `String` fields is **deliberately not defined** to allow for flexibility in indexing implementation, subject to the following:
@@ -88,8 +87,8 @@ The exact semantics for matching `String` fields is **deliberately not defined**
 The following value for the "property" field on the Comparator object
 MUST be supported for sorting:
 
-* "created" - The "created" date on the ContactCard.
-* "updated" - The "updated" date on the ContactCard.
+- "created" - The "created" date on the ContactCard.
+- "updated" - The "updated" date on the ContactCard.
 
 The following values for the "property" field on the Comparator object SHOULD be supported for sorting:
 
@@ -102,15 +101,14 @@ The following values for the "property" field on the Comparator object SHOULD be
 
 ## ContactCard/queryChanges
 
-This is a standard "/queryChanges" method as described in [@!RFC8620], Section 5.6.
+This is a standard "/queryChanges" method as described in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 5.6.
 
 ## ContactCard/set
 
-This is a standard "/set" method as described in [@!RFC8620], Section 5.3.
+This is a standard "/set" method as described in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 5.3.
 
-To set a new photo, the file must first be uploaded using the upload mechanism as described in [@!RFC8620], Section 6.1. This will give the client a valid blobId/size/type to use. The server SHOULD reject attempts to set a file that is not a recognised image type as the photo for a card.
+To set a new photo, the file must first be uploaded using the upload mechanism as described in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 6.1. This will give the client a valid blobId/size/type to use. The server SHOULD reject attempts to set a file that is not a recognised image type as the photo for a card.
 
 ## ContactCard/copy
 
-This is a standard "/copy" method as described in [@!RFC8620], Section 5.4.
-
+This is a standard "/copy" method as described in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 5.4.

--- a/spec/contacts/intro.mdown
+++ b/spec/contacts/intro.mdown
@@ -1,30 +1,30 @@
 # Introduction
 
-JMAP ([@!RFC8620] JSON Meta Application Protocol) is a generic protocol for synchronising data, such as mail, calendars or contacts, between a client and a server. It is optimised for mobile and web environments, and aims to provide a consistent interface to different data types.
+JMAP ([RFC8620](https://www.rfc-editor.org/rfc/rfc8620) JSON Meta Application Protocol) is a generic protocol for synchronising data, such as mail, calendars or contacts, between a client and a server. It is optimised for mobile and web environments, and aims to provide a consistent interface to different data types.
 
 This specification defines a data model for synchronising contacts between a client and a server using JMAP.
 
 ## Notational conventions
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in BCP 14 [@!RFC2119] [@!RFC8174] when, and only when, they appear in all capitals, as shown here.
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in BCP 14 [RFC2119](https://www.rfc-editor.org/rfc/rfc2119) [RFC8174](https://www.rfc-editor.org/rfc/rfc8174) when, and only when, they appear in all capitals, as shown here.
 
-Type signatures, examples and property descriptions in this document follow the conventions established in Section 1.1 of [@!RFC8620].  The Id and UnsignedInt data types defined in Sections 1.2 and 1.3 of [@!RFC8620] are also used in this document.
+Type signatures, examples and property descriptions in this document follow the conventions established in Section 1.1 of [RFC8620](https://www.rfc-editor.org/rfc/rfc8620).  The Id and UnsignedInt data types defined in Sections 1.2 and 1.3 of [RFC8620](https://www.rfc-editor.org/rfc/rfc8620) are also used in this document.
 
 ## Terminology
 
-The same terminology is used in this document as in the core JMAP specification, see [@!RFC8620], Section 1.6.
+The same terminology is used in this document as in the core JMAP specification, see [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 1.6.
 
 The terms AddressBook and ContactCard (with these specific capitalizations) are used to refer to the data types defined in this document and instances of those data types.
 
 ## Data Model Overview
 
-An Account (see [@!RFC8620], Section 1.6.2) with support for the contacts data model contains zero or more AddressBook objects, which is a named collection of zero or more ContactCards. A ContactCard is a representation of a person, company, or other entity, or a group of such entities, in RFCXXXX JSContact Card format. Each ContactCard belongs to one or more AddressBooks.
+An Account (see [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 1.6.2) with support for the contacts data model contains zero or more AddressBook objects, which is a named collection of zero or more ContactCards. A ContactCard is a representation of a person, company, or other entity, or a group of such entities, in RFCXXXX JSContact Card format. Each ContactCard belongs to one or more AddressBooks.
 
 In servers with support for JMAP Sharing [RFC XXX], data may be shared with other users. Sharing permissions are managed per AddressBook.
 
 ## Addition to the Capabilities Object
 
-The capabilities object is returned as part of the JMAP Session object; see [@!RFC8620], Section 2. This document defines two additional capability URIs.
+The capabilities object is returned as part of the JMAP Session object; see [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 2. This document defines two additional capability URIs.
 
 ### urn:ietf:params:jmap:contacts
 

--- a/spec/contacts/securityconsiderations.mdown
+++ b/spec/contacts/securityconsiderations.mdown
@@ -1,6 +1,6 @@
 # Security considerations
 
-All security considerations of JMAP ([@!RFC8620]) apply to this specification. Additional considerations specific to the data types and functionality introduced by this document are described in the following subsection.
+All security considerations of JMAP ([RFC8620](https://www.rfc-editor.org/rfc/rfc8620)) apply to this specification. Additional considerations specific to the data types and functionality introduced by this document are described in the following subsection.
 
 ## Privacy
 

--- a/spec/jmap/api.mdown
+++ b/spec/jmap/api.mdown
@@ -73,7 +73,7 @@ A **Response** object has the following properties:
 
 Unless otherwise specified, if the method call completed successfully, its response name is the same as the method name in the request.
 
-### Example Response:
+### Example Response
 
     {
       "methodResponses": [
@@ -115,7 +115,7 @@ Finally, methods that make changes to the server state often act upon a number o
 
 When an HTTP error response is returned to the client, the server
 SHOULD return a JSON "problem details" object as the response body,
-as per [@!RFC7807].
+as per [RFC7807](https://www.rfc-editor.org/rfc/rfc7807).
 
 The following problem types are defined:
 
@@ -150,7 +150,6 @@ Another example:
       "status": 400,
       "detail": "The request is larger than the server is willing to process."
     }
-
 
 ### Method-Level Errors
 
@@ -209,7 +208,7 @@ A **ResultReference** object has the following properties:
 - **name**: `String`
   The required name of a response to that method call.
 - **path**: `String`
-  A pointer into the arguments of the response selected via the name and resultOf properties. This is a JSON Pointer [@!RFC6901], except it also allows the use of `*` to map through an array (see the description below).
+  A pointer into the arguments of the response selected via the name and resultOf properties. This is a JSON Pointer [RFC6901](https://www.rfc-editor.org/rfc/rfc6901), except it also allows the use of `*` to map through an array (see the description below).
 
 To resolve:
 
@@ -220,7 +219,7 @@ To resolve:
    *ResultReference*, evaluation fails.
 
 3. Apply the *path* to the arguments object of the response (the second item in
-   the response array) following the JSON Pointer algorithm [@!RFC6901], except with the following addition in "Evaluation" (see Section 4):
+   the response array) following the JSON Pointer algorithm [RFC6901](https://www.rfc-editor.org/rfc/rfc6901), except with the following addition in "Evaluation" (see Section 4):
 
      If the currently referenced value is a JSON array, the reference token may
      be exactly the single character `*`, making the new referenced value the result of applying the rest of the JSON Pointer tokens to every item in the array and returning the results in the same order in a new array.
@@ -376,7 +375,7 @@ them.
 
 ## Localisation of User-Visible Strings
 
-If returning a custom string to be displayed to the user, for example, an error message, the server SHOULD use information from the Accept-Language header of the request (as defined in Section 5.3.5 of [@!RFC7231]) to choose the best available localisation. The Content-Language header of the response (see section 3.1.3.2 of [@!RFC7231]) SHOULD indicate the language being used for user-visible strings.
+If returning a custom string to be displayed to the user, for example, an error message, the server SHOULD use information from the Accept-Language header of the request (as defined in Section 5.3.5 of [RFC7231](https://www.rfc-editor.org/rfc/rfc7231)) to choose the best available localisation. The Content-Language header of the response (see section 3.1.3.2 of [RFC7231](https://www.rfc-editor.org/rfc/rfc7231)) SHOULD indicate the language being used for user-visible strings.
 
 For example, suppose a request was made with the following header:
 
@@ -393,7 +392,6 @@ As always, the server must be strict about data received from the client. Argume
 ## Concurrency
 
 Method calls within a single request MUST be executed in order. However, method calls from different concurrent API requests may be interleaved. This means that the data on the server may change between two method calls within a single API request.
-
 
 # The Core/echo Method
 
@@ -414,7 +412,6 @@ Response:
       "hello": true,
       "high": 5
     }, "b3ff" ]]
-
 
 # Standard Methods and Naming Convention
 
@@ -539,18 +536,18 @@ The *Foo/set* method takes the following arguments:
 - **update**: `Id[PatchObject]|null`
   A map of an id to a Patch object to apply to the current Foo object with that id, or `null` if no objects are to be updated.
 
-    A *PatchObject* is of type `String[*]` and represents an unordered set of patches.  The keys are a path in JSON Pointer Format [@!RFC6901], with an implicit leading "/" (i.e., prefix each key with "/" before applying the JSON Pointer evaluation algorithm).
+    A *PatchObject* is of type `String[*]` and represents an unordered set of patches.  The keys are a path in JSON Pointer Format [RFC6901](https://www.rfc-editor.org/rfc/rfc6901), with an implicit leading "/" (i.e., prefix each key with "/" before applying the JSON Pointer evaluation algorithm).
 
     All paths MUST also conform to the following restrictions; if there is any violation, the update MUST be rejected with an `invalidPatch` error:
 
-    * The pointer MUST NOT reference inside an array (i.e., you MUST NOT insert/delete from an array; the array MUST be replaced in its entirety instead).
-    * All parts prior to the last (i.e., the value after the final slash) MUST already exist on the object being patched.
-    * There MUST NOT be two patches in the PatchObject where the pointer of one is the prefix of the pointer of the other, e.g., "alerts/1/offset" and "alerts".
+  - The pointer MUST NOT reference inside an array (i.e., you MUST NOT insert/delete from an array; the array MUST be replaced in its entirety instead).
+  - All parts prior to the last (i.e., the value after the final slash) MUST already exist on the object being patched.
+  - There MUST NOT be two patches in the PatchObject where the pointer of one is the prefix of the pointer of the other, e.g., "alerts/1/offset" and "alerts".
 
     The value associated with each pointer determines how to apply that patch:
 
-    * If `null`, set to the default value if specified for this property; otherwise, remove the property from the patched object. If the key is not present in the parent, this a no-op.
-    * Anything else: The value to set for this property (this may be a replacement or addition to the object being patched).
+  - If `null`, set to the default value if specified for this property; otherwise, remove the property from the patched object. If the key is not present in the parent, this a no-op.
+  - Anything else: The value to set for this property (this may be a replacement or addition to the object being patched).
 
     Any server-set properties MAY be included in the patch if their value is identical to the current server value (before applying the patches to the object). Otherwise, the update MUST be rejected with an *invalidProperties* SetError.
 
@@ -630,9 +627,9 @@ The following SetError types are defined and may be returned for set operations 
 - `invalidProperties`: (create; update). The record given is invalid in
   some way. For example:
 
-    - It contains properties that are invalid according to the type specification of this record type.
-    - It contains a property that may only be set by the server (e.g., "id") and is different to the current value. Note, to allow clients to pass whole objects back, it is not an error to include a server-set property in an update as long as the value is identical to the current value on the server.
-    - There is a reference to another record (foreign key), and the given id does not correspond to a valid record.
+  - It contains properties that are invalid according to the type specification of this record type.
+  - It contains a property that may only be set by the server (e.g., "id") and is different to the current value. Note, to allow clients to pass whole objects back, it is not an error to include a server-set property in an update as long as the value is identical to the current value on the server.
+  - There is a reference to another record (foreign key), and the given id does not correspond to a valid record.
 
     The SetError object SHOULD also have a property called *properties* of type `String[]` that lists **all** the properties that were invalid.
 
@@ -713,7 +710,6 @@ The following additional errors may be returned instead of the *Foo/copy* respon
 
 `stateMismatch`: An `ifInState` argument was supplied and it does not match the current state, or an `ifFromInState` argument was supplied and it does not match the current state in the from account.
 
-
 ## /query
 
 For data sets where the total amount of data is expected to be very small, clients can just fetch the complete set of data and then do any sorting/filtering locally. However, for large data sets (e.g., multi-gigabyte mailboxes), the client needs to be able to search/sort/window the data type on the server.
@@ -729,12 +725,12 @@ A call to *Foo/query* takes the following arguments:
 
     A **FilterOperator** object has the following properties:
 
-    - **operator**: `String`
+  - **operator**: `String`
       This MUST be one of the following strings: "AND" / "OR" / "NOT":
-      - **AND**: All of the conditions must match for the filter to match.
-      - **OR**: At least one of the conditions must match for the filter to match.
-      - **NOT**: None of the conditions must match for the filter to match.
-    - **conditions**: `(FilterOperator|FilterCondition)[]`
+    - **AND**: All of the conditions must match for the filter to match.
+    - **OR**: At least one of the conditions must match for the filter to match.
+    - **NOT**: None of the conditions must match for the filter to match.
+  - **conditions**: `(FilterOperator|FilterCondition)[]`
       The conditions to evaluate against each record.
 
     A **FilterCondition** is an `object` whose allowed properties and semantics depend on the data type and is defined in the */query* method specification for that type. It MUST NOT have an *operator* property.
@@ -744,28 +740,28 @@ A call to *Foo/query* takes the following arguments:
 
     A **Comparator** has the following properties:
 
-    - **property**: `String`
+  - **property**: `String`
       The name of the property on the Foo objects to compare.
-    - **isAscending**: `Boolean` (optional; default: true)
+  - **isAscending**: `Boolean` (optional; default: true)
       If `true`, sort in ascending order. If `false`, reverse the comparator's results to sort in descending order.
-    - **collation**: `String` (optional; default is server dependent)
-      The identifier, as registered in the collation registry defined in [@!RFC4790], for the algorithm to use when comparing the order of strings. The algorithms the server supports are advertised in the capabilities object returned with the Session object (see Section 2).
+  - **collation**: `String` (optional; default is server dependent)
+      The identifier, as registered in the collation registry defined in [RFC4790](https://www.rfc-editor.org/rfc/rfc4790), for the algorithm to use when comparing the order of strings. The algorithms the server supports are advertised in the capabilities object returned with the Session object (see Section 2).
 
         If omitted, the default algorithm is server-dependent, but:
 
         1. It MUST be unicode-aware.
         2. It MAY be selected based on an Accept-Language header in the
-           request (as defined in [@!RFC7231], Section 5.3.5), or out-of-band information about the user's language/locale.
+           request (as defined in [RFC7231](https://www.rfc-editor.org/rfc/rfc7231), Section 5.3.5), or out-of-band information about the user's language/locale.
         3. It SHOULD be case insensitive where such a concept makes sense for a
-           language/locale. Where the user's language is unknown, it is RECOMMENDED to follow the advice in Section 5.2.3 of [@!RFC8264].
+           language/locale. Where the user's language is unknown, it is RECOMMENDED to follow the advice in Section 5.2.3 of [RFC8264](https://www.rfc-editor.org/rfc/rfc8264).
 
-        The "i;unicode-casemap" collation [@!RFC5051] and the Unicode Collation Algorithm (http://www.unicode.org/reports/tr10/) are two examples that fulfil these criterion and provide reasonable behaviour for a large number of languages.
+        The "i;unicode-casemap" collation [RFC5051](https://www.rfc-editor.org/rfc/rfc5051) and the Unicode Collation Algorithm (<http://www.unicode.org/reports/tr10/>) are two examples that fulfil these criterion and provide reasonable behaviour for a large number of languages.
 
         When the property being compared is not a string, the *collation* property is ignored, and the following comparison rules apply based on the type. In ascending order:
 
-        - `Boolean`: `false` comes before `true`.
-        - `Number`: A lower number comes before a higher number.
-        - `Date`/`UTCDate`: The earlier date comes first.
+    - `Boolean`: `false` comes before `true`.
+    - `Number`: A lower number comes before a higher number.
+    - `Date`/`UTCDate`: The earlier date comes first.
 
     The Comparator object may also have additional properties as required for
     specific sort operations defined in a type's /query method.
@@ -874,8 +870,8 @@ The response has the following arguments:
 
     An **AddedItem** object has the following properties:
 
-    - **id**: `Id`
-    - **index**: `UnsignedInt`
+  - **id**: `Id`
+  - **index**: `UnsignedInt`
 
 The result of this is that if the client has a cached sparse array of Foo ids corresponding to the results in the old state, then:
 

--- a/spec/jmap/binary.mdown
+++ b/spec/jmap/binary.mdown
@@ -2,7 +2,7 @@
 
 Binary data is referenced by a *blobId* in JMAP and uploaded/downloaded separately to the core API. The blobId solely represents the raw bytes of data, not any associated metadata such as a file name or content type. Such metadata is stored alongside the blobId in the object referencing it. The data represented by a blobId is immutable.
 
-Any blobId that exists within an account may be used when creating/updating another object in that account. For example, an Email type may have a blobId that represents the object in Internet Message Format [@!RFC5322]. A client could create a new Email object with an attachment and use this blobId, in effect attaching the old message to the new one. Similarly, it could attach any existing attachment of an old message without having to download and upload it again.
+Any blobId that exists within an account may be used when creating/updating another object in that account. For example, an Email type may have a blobId that represents the object in Internet Message Format [RFC5322](https://www.rfc-editor.org/rfc/rfc5322). A client could create a new Email object with an attachment and use this blobId, in effect attaching the old message to the new one. Similarly, it could attach any existing attachment of an old message without having to download and upload it again.
 
 When the client uses a blobId in a create/update, the server MAY assign a new blobId to refer to the same binary data within the new/updated object. If it does so, it MUST return any properties that contain a changed blobId in the created/updated response, so the client gets the new ids.
 
@@ -21,46 +21,46 @@ A blob that is not referenced by a JMAP object (e.g., as a message attachment) M
 
 ## Uploading Binary Data
 
-There is a single endpoint that handles all file uploads for an account, regardless of what they are to be used for. The Session object (see Section 2) has an *uploadUrl* property in URI Template (level 1) format [@!RFC6570], which MUST contain a variable called `accountId`. The client may use this template in combination with an *accountId* to get the URL of the file upload resource.
+There is a single endpoint that handles all file uploads for an account, regardless of what they are to be used for. The Session object (see Section 2) has an *uploadUrl* property in URI Template (level 1) format [RFC6570](https://www.rfc-editor.org/rfc/rfc6570), which MUST contain a variable called `accountId`. The client may use this template in combination with an *accountId* to get the URL of the file upload resource.
 
 To upload a file, the client submits an authenticated POST request to the file upload resource.
 
 A successful request MUST return a single JSON object with the following properties as the response:
 
-- **accountId**: `Id`
+* **accountId**: `Id`
   The id of the account used for the call.
-- **blobId**: `Id`
+* **blobId**: `Id`
   The id representing the binary data uploaded. The data for this id is immutable. The id *only* refers to the binary data, not any metadata.
-- **type**: `String`
-  The media type of the file (as specified in [@!RFC6838], Section 4.2) as set in the Content-Type header of the upload HTTP request.
-- **size**: `UnsignedInt`
+* **type**: `String`
+  The media type of the file (as specified in [RFC6838](https://www.rfc-editor.org/rfc/rfc6838), Section 4.2) as set in the Content-Type header of the upload HTTP request.
+* **size**: `UnsignedInt`
   The size of the file in octets.
 
 If identical binary content to an existing blob in the account is uploaded, the existing blobId MAY be returned.
 
 Clients should use the blobId returned in a timely manner. Under rare circumstances, the server may have deleted the blob before the client uses it; the client should keep a reference to the local file so it can upload it again in such a situation.
 
-When an HTTP error response is returned to the client, the server SHOULD return a JSON "problem details" object as the response body, as per [@!RFC7807].
+When an HTTP error response is returned to the client, the server SHOULD return a JSON "problem details" object as the response body, as per [RFC7807](https://www.rfc-editor.org/rfc/rfc7807).
 
 As access controls are often determined by the object holding the reference to a blob, unreferenced blobs MUST only be accessible to the uploader, even in shared accounts.
 
 ## Downloading Binary Data
 
-The Session object (see Section 2) has a *downloadUrl* property, which is in URI Template (level 1) format [@!RFC6570]. The URL MUST contain variables called `accountId`, `blobId`, `type`, and `name`.
+The Session object (see Section 2) has a *downloadUrl* property, which is in URI Template (level 1) format [RFC6570](https://www.rfc-editor.org/rfc/rfc6570). The URL MUST contain variables called `accountId`, `blobId`, `type`, and `name`.
 
 To download a file, the client makes an authenticated GET request to the download URL with the appropriate variables substituted in:
 
-- `accountId`: The id of the account to which the record with the blobId
+* `accountId`: The id of the account to which the record with the blobId
    belongs.
-- `blobId`: The blobId representing the data of the file to download.
-- `type`: The type for the server to set in the `Content-Type` header of the
+* `blobId`: The blobId representing the data of the file to download.
+* `type`: The type for the server to set in the `Content-Type` header of the
   response; the blobId only represents the binary data and does not have a content-type innately associated with it.
-- `name`: The name for the file; the server MUST return this as the filename if
+* `name`: The name for the file; the server MUST return this as the filename if
   it sets a `Content-Disposition` header.
 
 As the data for a particular blobId is immutable, and thus the response in the generated download URL is too, implementors are recommended to set long cache times and use the "immutable" Cache-Control extension [@?RFC8246] for successful responses, for example, `Cache-Control: private, immutable, max-age=31536000`.
 
-When an HTTP error response is returned to the client, the server SHOULD return a JSON "problem details" object as the response body, as per [@!RFC7807].
+When an HTTP error response is returned to the client, the server SHOULD return a JSON "problem details" object as the response body, as per [RFC7807](https://www.rfc-editor.org/rfc/rfc7807).
 
 ## Blob/copy
 
@@ -68,22 +68,22 @@ Binary data may be copied **between** two different accounts using the *Blob/cop
 
 The *Blob/copy* method takes the following arguments:
 
-- **fromAccountId**: `Id`
+* **fromAccountId**: `Id`
   The id of the account to copy blobs from.
-- **accountId**: `Id`
+* **accountId**: `Id`
   The id of the account to copy blobs to.
-- **blobIds**: `Id[]`
+* **blobIds**: `Id[]`
   A list of ids of blobs to copy to the other account.
 
 The response has the following arguments:
 
-- **fromAccountId**: `Id`
+* **fromAccountId**: `Id`
   The id of the account blobs were copied from.
-- **accountId**: `Id`
+* **accountId**: `Id`
   The id of the account blobs were copied to.
-- **copied**: `Id[Id]|null`
+* **copied**: `Id[Id]|null`
   A map of the blobId in the *fromAccount* to the id for the blob in the account it was copied to, or `null` if none were successfully copied.
-- **notCopied**: `Id[SetError]|null`
+* **notCopied**: `Id[SetError]|null`
   A map of blobId to a SetError object for each blob that failed to be copied, or `null` if none.
 
 The **SetError** may be any of the standard set errors that may be returned for a *create*, as defined in Section 5.3. In addition, the `notFound` SetError error may be returned if the blobId to be copied cannot be found.

--- a/spec/jmap/ianaconsiderations.mdown
+++ b/spec/jmap/ianaconsiderations.mdown
@@ -2,7 +2,7 @@
 
 ## Assignment of jmap Service Name
 
-IANA has assigned the 'jmap' service name in the "Service Name and Transport Protocol Port Number Registry" [@!RFC6335].
+IANA has assigned the 'jmap' service name in the "Service Name and Transport Protocol Port Number Registry" [RFC6335](https://www.rfc-editor.org/rfc/rfc6335).
 
 Service Name: jmap
 
@@ -14,29 +14,29 @@ Contact: IETF Chair
 
 Description: JSON Meta Application Protocol
 
-Reference: [@!RFC8620]
+Reference: [RFC8620](https://www.rfc-editor.org/rfc/rfc8620)
 
 Assignment Notes: This service name was previously assigned under the name *JSON Mail Access Protocol*. This has been de-assigned and re-assigned with the approval of the previous assignee.
 
 ## Registration of Well-Known URI suffix for JMAP
 
-IANA has registered the following suffix in the "Well-Known URIs" registry for JMAP, as described in [@!RFC8615]:
+IANA has registered the following suffix in the "Well-Known URIs" registry for JMAP, as described in [RFC8615](https://www.rfc-editor.org/rfc/rfc8615):
 
 URI Suffix: jmap
 
 Change Controller: IETF
 
-Specification Document: [@!RFC8620], Section 2.2.
+Specification Document: [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 2.2.
 
 ## Registration of the jmap URN Sub-namespace
 
-IANA has registered the following URN sub-namespace in the "IETF URN Sub-namespace for Registered Protocol Parameter Identifiers" registry within the "Uniform Resource Name (URN) Namespace for IETF Use" registry as described in [@!RFC3553].
+IANA has registered the following URN sub-namespace in the "IETF URN Sub-namespace for Registered Protocol Parameter Identifiers" registry within the "Uniform Resource Name (URN) Namespace for IETF Use" registry as described in [RFC3553](https://www.rfc-editor.org/rfc/rfc3553).
 
 Registered Parameter Identifier: jmap
 
-Reference: [@!RFC8620], Section 9.4
+Reference: [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 9.4
 
-IANA Registry Reference: http://www.iana.org/assignments/jmap
+IANA Registry Reference: <http://www.iana.org/assignments/jmap>
 
 ## Creation of "JMAP Capabilities" Registry
 
@@ -62,7 +62,7 @@ Registration requests can be sent to <iana@iana.org>.
 
 ### Designated Expert Review
 
-For a limited-use registration, the primary concern of the designated expert (DE) is preventing name collisions and encouraging the submitter to document security and privacy considerations; a published specification is not required. For a common-use registration, the DE is expected to confirm that suitable documentation, as described in Section 4.6 of [@!RFC8126], is available. The DE should also verify that the capability does not conflict with work that is active or already published within the IETF.
+For a limited-use registration, the primary concern of the designated expert (DE) is preventing name collisions and encouraging the submitter to document security and privacy considerations; a published specification is not required. For a common-use registration, the DE is expected to confirm that suitable documentation, as described in Section 4.6 of [RFC8126](https://www.rfc-editor.org/rfc/rfc8126), is available. The DE should also verify that the capability does not conflict with work that is active or already published within the IETF.
 
 Before a period of 30 days has passed, the DE will either approve or deny the registration request and publish a notice of the decision to the JMAP WG mailing list or its successor, as well as inform IANA. A denial notice must be justified by an explanation, and, in the cases where it is possible, concrete suggestions on how the request can be modified so as to become acceptable should be provided.
 
@@ -80,7 +80,7 @@ The owner of a JMAP capability may pass responsibility to another person or agen
 
 The IESG may reassign responsibility for a JMAP capability. The most common case of this will be to enable changes to be made to capabilities where the author of the registration has died, moved out of contact, or is otherwise unable to make changes that are important to the community.
 
-### JMAP Capabilities Registry Template:
+### JMAP Capabilities Registry Template
 
 Capability name: (see capability property in Section 2)
 
@@ -96,25 +96,25 @@ Security and privacy considerations:
 
 Capability Name: `urn:ietf:params:jmap:core`
 
-Specification document: [@!RFC8620], Section 2
+Specification document: [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 2
 
 Intended use: common
 
 Change Controller: IETF
 
-Security and privacy considerations: [@!RFC8620], Section 8.
+Security and privacy considerations: [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 8.
 
 ### Registration for JMAP Error Placeholder in JMAP Capabilities Registry
 
 Capability Name: `urn:ietf:params:jmap:error:`
 
-Specification document: [@!RFC8620], Section 9.5
+Specification document: [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 9.5
 
 Intended use: placeholder
 
 Change Controller: IETF
 
-Security and privacy considerations: [@!RFC8620], Section 8.
+Security and privacy considerations: [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 8.
 
 ## Creation of "JMAP Error Codes" registry
 
@@ -140,7 +140,7 @@ The designated expert should review the following aspects of the registration:
 
 Steps 3-6 are meant to promote a higher-quality registry. However, the expert is encouraged to approve any registration that would not actively harm JMAP interoperability to make this a relatively lightweight process.
 
-### JMAP Error Codes Registry Template:
+### JMAP Error Codes Registry Template
 
 JMAP Error Code:
 
@@ -156,34 +156,34 @@ Description:
 
 | JMAP Error Code | Intended Use | Change Controller | Reference | Description |
 | --- | --- | --- | --- | --- |
-| accountNotFound | common | IETF | [@!RFC8620] Section 3.6.2 | The accountId does not correspond to a valid account. |
-| accountNotSupportedByMethod | common | IETF | [@!RFC8620] Section 3.6.2 | The accountId given corresponds to a valid account, but the account does not support this method or data type. |
-| accountReadOnly | common | IETF | [@!RFC8620] Section 3.6.2 | This method modifies state, but the account is read-only (as returned on the corresponding Account in the Session object). |
-| anchorNotFound | common | IETF | [@!RFC8620] Section 5.5 | An anchor argument was supplied, but it cannot be found in the results of the query. |
-| alreadyExists | common | IETF | [@!RFC8620] Section 5.4 | The server forbids duplicates, and the record already exists in the target account. An existingId property of type Id MUST be included on the SetError object with the id of the existing record. |
-| cannotCalculateChanges | common | IETF | [@!RFC8620] sections 5.2 and 5.6 |  The server cannot calculate the changes from the state string given by the client. |
-| forbidden | common | IETF | [@!RFC8620] sections 3.5.2, 5.3, and 7.2.1 | The action would violate an ACL or other permissions policy. |
-| fromAccountNotFound | common | IETF | [@!RFC8620] sections 5.4 and 6.3 | The fromAccountId does not correspond to a valid account. |
-| fromAccountNotSupportedByMethod | common | IETF | [@!RFC8620] Section 5.4 | The fromAccountId given corresponds to a valid account, but the account does not support this data type. |
-| invalidArguments | common | IETF | [@!RFC8620] Section 3.6.2 | One of the arguments is of the wrong type or otherwise invalid, or a required argument is missing. |
-| invalidPatch | common | IETF | [@!RFC8620] Section 5.3 |  The PatchObject given to update the record was not a valid patch. |
-| invalidProperties | common | IETF | [@!RFC8620] Section 5.3 | The record given is invalid. |
-| notFound | common | IETF | [@!RFC8620] Section 5.3 | The id given cannot be found. |
-| notJSON | common | IETF | [@!RFC8620] Section 3.6.1 | The content type of the request was not application/json or the request did not parse as I-JSON. |
-| notRequest | common | IETF | [@!RFC8620] Section 3.6.1 | The request parsed as JSON but did not match the type signature of the Request object. |
-| overQuota | common | IETF | [@!RFC8620] Section 5.3 | The create would exceed a server-defined limit on the number or total size of objects of this type. |
-| rateLimit | common | IETF | [@!RFC8620] Section 5.3 | Too many objects of this type have been created recently, and a server-defined rate limit has been reached. It may work if tried again later. |
-| requestTooLarge | common | IETF | [@!RFC8620] sections 5.1 and 5.3 | The total number of actions exceeds the maximum number the server is willing to process in a single method call. |
-| invalidResultReference | common | IETF | [@!RFC8620] Section 3.6.2 | The method used a result reference for one of its arguments, but this failed to resolve. |
-| serverFail | common | IETF | [@!RFC8620] Section 3.6.2 | An unexpected or unknown error occurred during the processing of the call. The method call made no changes to the server’s state. |
-| serverPartialFail | limited | IETF | [@!RFC8620] Section 3.6.2 | Some, but not all, expected changes described by the method occurred. The client MUST re-synchronise impacted data to determine server state. Use of this error is strongly discouraged. |
-| serverUnavailable | common | IETF | [@!RFC8620] Section 3.6.2 | Some internal server resource was temporarily unavailable. Attempting the same operation later (perhaps after a backoff with a random factor) may succeed. |
-| singleton | common | IETF | [@!RFC8620] Section 5.3 | This is a singleton type, so you cannot create another one or destroy the existing one. |
-| stateMismatch | common | IETF | [@!RFC8620] Section 5.3 | An ifInState argument was supplied, and it does not match the current state. |
-| tooLarge | common | IETF | [@!RFC8620] Section 5.3 | The action would result in an object that exceeds a server-defined limit for the maximum size of a single object of this type. |
-| tooManyChanges | common | IETF | [@!RFC8620] Section 5.6 | There are more changes than the client’s maxChanges argument. |
-| unknownCapability | common | IETF | [@!RFC8620] Section 3.6.1 | The client included a capability in the “using” property of the request that the server does not support. |
-| unknownMethod | common | IETF | [@!RFC8620] Section 3.6.2 | The server does not recognise this method name. |
-| unsupportedFilter | common | IETF | [@!RFC8620] Section 5.5 | The filter is syntactically valid, but the server cannot process it. |
-| unsupportedSort | common | IETF | [@!RFC8620] Section 5.5 |The sort is syntactically valid, but includes a property the server does not support sorting on, or a collation method it does not recognise. |
-| willDestroy | common | IETF | [@!RFC8620] Section 5.3 | The client requested an object be both updated and destroyed in the same /set request, and the server has decided to therefore ignore the update. |
+| accountNotFound | common | IETF | [RFC8620](https://www.rfc-editor.org/rfc/rfc8620) Section 3.6.2 | The accountId does not correspond to a valid account. |
+| accountNotSupportedByMethod | common | IETF | [RFC8620](https://www.rfc-editor.org/rfc/rfc8620) Section 3.6.2 | The accountId given corresponds to a valid account, but the account does not support this method or data type. |
+| accountReadOnly | common | IETF | [RFC8620](https://www.rfc-editor.org/rfc/rfc8620) Section 3.6.2 | This method modifies state, but the account is read-only (as returned on the corresponding Account in the Session object). |
+| anchorNotFound | common | IETF | [RFC8620](https://www.rfc-editor.org/rfc/rfc8620) Section 5.5 | An anchor argument was supplied, but it cannot be found in the results of the query. |
+| alreadyExists | common | IETF | [RFC8620](https://www.rfc-editor.org/rfc/rfc8620) Section 5.4 | The server forbids duplicates, and the record already exists in the target account. An existingId property of type Id MUST be included on the SetError object with the id of the existing record. |
+| cannotCalculateChanges | common | IETF | [RFC8620](https://www.rfc-editor.org/rfc/rfc8620) sections 5.2 and 5.6 |  The server cannot calculate the changes from the state string given by the client. |
+| forbidden | common | IETF | [RFC8620](https://www.rfc-editor.org/rfc/rfc8620) sections 3.5.2, 5.3, and 7.2.1 | The action would violate an ACL or other permissions policy. |
+| fromAccountNotFound | common | IETF | [RFC8620](https://www.rfc-editor.org/rfc/rfc8620) sections 5.4 and 6.3 | The fromAccountId does not correspond to a valid account. |
+| fromAccountNotSupportedByMethod | common | IETF | [RFC8620](https://www.rfc-editor.org/rfc/rfc8620) Section 5.4 | The fromAccountId given corresponds to a valid account, but the account does not support this data type. |
+| invalidArguments | common | IETF | [RFC8620](https://www.rfc-editor.org/rfc/rfc8620) Section 3.6.2 | One of the arguments is of the wrong type or otherwise invalid, or a required argument is missing. |
+| invalidPatch | common | IETF | [RFC8620](https://www.rfc-editor.org/rfc/rfc8620) Section 5.3 |  The PatchObject given to update the record was not a valid patch. |
+| invalidProperties | common | IETF | [RFC8620](https://www.rfc-editor.org/rfc/rfc8620) Section 5.3 | The record given is invalid. |
+| notFound | common | IETF | [RFC8620](https://www.rfc-editor.org/rfc/rfc8620) Section 5.3 | The id given cannot be found. |
+| notJSON | common | IETF | [RFC8620](https://www.rfc-editor.org/rfc/rfc8620) Section 3.6.1 | The content type of the request was not application/json or the request did not parse as I-JSON. |
+| notRequest | common | IETF | [RFC8620](https://www.rfc-editor.org/rfc/rfc8620) Section 3.6.1 | The request parsed as JSON but did not match the type signature of the Request object. |
+| overQuota | common | IETF | [RFC8620](https://www.rfc-editor.org/rfc/rfc8620) Section 5.3 | The create would exceed a server-defined limit on the number or total size of objects of this type. |
+| rateLimit | common | IETF | [RFC8620](https://www.rfc-editor.org/rfc/rfc8620) Section 5.3 | Too many objects of this type have been created recently, and a server-defined rate limit has been reached. It may work if tried again later. |
+| requestTooLarge | common | IETF | [RFC8620](https://www.rfc-editor.org/rfc/rfc8620) sections 5.1 and 5.3 | The total number of actions exceeds the maximum number the server is willing to process in a single method call. |
+| invalidResultReference | common | IETF | [RFC8620](https://www.rfc-editor.org/rfc/rfc8620) Section 3.6.2 | The method used a result reference for one of its arguments, but this failed to resolve. |
+| serverFail | common | IETF | [RFC8620](https://www.rfc-editor.org/rfc/rfc8620) Section 3.6.2 | An unexpected or unknown error occurred during the processing of the call. The method call made no changes to the server’s state. |
+| serverPartialFail | limited | IETF | [RFC8620](https://www.rfc-editor.org/rfc/rfc8620) Section 3.6.2 | Some, but not all, expected changes described by the method occurred. The client MUST re-synchronise impacted data to determine server state. Use of this error is strongly discouraged. |
+| serverUnavailable | common | IETF | [RFC8620](https://www.rfc-editor.org/rfc/rfc8620) Section 3.6.2 | Some internal server resource was temporarily unavailable. Attempting the same operation later (perhaps after a backoff with a random factor) may succeed. |
+| singleton | common | IETF | [RFC8620](https://www.rfc-editor.org/rfc/rfc8620) Section 5.3 | This is a singleton type, so you cannot create another one or destroy the existing one. |
+| stateMismatch | common | IETF | [RFC8620](https://www.rfc-editor.org/rfc/rfc8620) Section 5.3 | An ifInState argument was supplied, and it does not match the current state. |
+| tooLarge | common | IETF | [RFC8620](https://www.rfc-editor.org/rfc/rfc8620) Section 5.3 | The action would result in an object that exceeds a server-defined limit for the maximum size of a single object of this type. |
+| tooManyChanges | common | IETF | [RFC8620](https://www.rfc-editor.org/rfc/rfc8620) Section 5.6 | There are more changes than the client’s maxChanges argument. |
+| unknownCapability | common | IETF | [RFC8620](https://www.rfc-editor.org/rfc/rfc8620) Section 3.6.1 | The client included a capability in the “using” property of the request that the server does not support. |
+| unknownMethod | common | IETF | [RFC8620](https://www.rfc-editor.org/rfc/rfc8620) Section 3.6.2 | The server does not recognise this method name. |
+| unsupportedFilter | common | IETF | [RFC8620](https://www.rfc-editor.org/rfc/rfc8620) Section 5.5 | The filter is syntactically valid, but the server cannot process it. |
+| unsupportedSort | common | IETF | [RFC8620](https://www.rfc-editor.org/rfc/rfc8620) Section 5.5 |The sort is syntactically valid, but includes a property the server does not support sorting on, or a collation method it does not recognise. |
+| willDestroy | common | IETF | [RFC8620](https://www.rfc-editor.org/rfc/rfc8620) Section 5.3 | The client requested an object be both updated and destroyed in the same /set request, and the server has decided to therefore ignore the update. |

--- a/spec/jmap/intro.mdown
+++ b/spec/jmap/intro.mdown
@@ -10,9 +10,9 @@ JMAP is designed to be horizontally scalable to a very large number of users. Th
 
 ## Notational Conventions
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in BCP 14 [@!RFC2119] [@!RFC8174] when, and only when, they appear in all capitals, as shown here.
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in BCP 14 [RFC2119](https://www.rfc-editor.org/rfc/rfc2119) [RFC8174](https://www.rfc-editor.org/rfc/rfc8174) when, and only when, they appear in all capitals, as shown here.
 
-The underlying format used for this specification is JSON. Consequently, the terms "object" and "array" as well as the four primitive types (strings, numbers, booleans, and null) are to be interpreted as described in Section 1 of [@!RFC8259]. Unless otherwise noted, all the property names and values are case sensitive.
+The underlying format used for this specification is JSON. Consequently, the terms "object" and "array" as well as the four primitive types (strings, numbers, booleans, and null) are to be interpreted as described in Section 1 of [RFC8259](https://www.rfc-editor.org/rfc/rfc8259). Unless otherwise noted, all the property names and values are case sensitive.
 
 Some examples in this document contain "partial" JSON documents used for illustrative purposes.  In these examples, three periods "..." are used to indicate a portion of the document that has been removed for compactness.
 
@@ -47,7 +47,7 @@ signature. These have the following meanings:
 
 All record ids are assigned by the server and are immutable.
 
-Where `Id` is given as a data type, it means a `String` of at least 1 and a maximum of 255 octets in size, and it MUST only contain characters from the "URL and Filename Safe" base64 alphabet, as defined in Section 5 of [@!RFC4648], excluding the pad character (`=`). This means the allowed characters are the ASCII alphanumeric characters (`A-Za-z0-9`), hyphen (`-`), and underscore (`_`).
+Where `Id` is given as a data type, it means a `String` of at least 1 and a maximum of 255 octets in size, and it MUST only contain characters from the "URL and Filename Safe" base64 alphabet, as defined in Section 5 of [RFC4648](https://www.rfc-editor.org/rfc/rfc4648), excluding the pad character (`=`). This means the allowed characters are the ASCII alphanumeric characters (`A-Za-z0-9`), hyphen (`-`), and underscore (`_`).
 
 These characters are safe to use in almost any context (e.g., filesystems,
 URIs, and IMAP atoms). For maximum safety, servers SHOULD also follow defensive
@@ -73,15 +73,15 @@ Where `UnsignedInt` is given as a data type, it means an `Int` where the value M
 
 ## The Date and UTCDate Data Types
 
-Where `Date` is given as a type, it means a string in *date-time* format [@!RFC3339]. To ensure a normalised form, the *time-secfrac* MUST always be omitted if zero, and any letters in the string (e.g., "T" and "Z") MUST be uppercase. For example, `"2014-10-30T14:12:00+08:00"`.
+Where `Date` is given as a type, it means a string in *date-time* format [RFC3339](https://www.rfc-editor.org/rfc/rfc3339). To ensure a normalised form, the *time-secfrac* MUST always be omitted if zero, and any letters in the string (e.g., "T" and "Z") MUST be uppercase. For example, `"2014-10-30T14:12:00+08:00"`.
 
 Where `UTCDate` is given as a type, it means a `Date` where the *time-offset* component MUST be `Z` (i.e., it must be in UTC time). For example, `"2014-10-30T06:12:00Z"`.
 
 ## JSON as the Data Encoding Format
 
-JSON is a text-based data interchange format as specified in [@!RFC8259]. The Internet JSON (I-JSON) format defined in [@!RFC7493] is a strict subset of this, adding restrictions to avoid potentially confusing scenarios (for example, it mandates that an object MUST NOT have two members with the same name).
+JSON is a text-based data interchange format as specified in [RFC8259](https://www.rfc-editor.org/rfc/rfc8259). The Internet JSON (I-JSON) format defined in [RFC7493](https://www.rfc-editor.org/rfc/rfc7493) is a strict subset of this, adding restrictions to avoid potentially confusing scenarios (for example, it mandates that an object MUST NOT have two members with the same name).
 
-All data sent from the client to the server or from the server to the client (except binary file upload/download) MUST be valid I-JSON according to the RFC and is therefore case sensitive and encoded in UTF-8 [@!RFC3629].
+All data sent from the client to the server or from the server to the client (except binary file upload/download) MUST be valid I-JSON according to the RFC and is therefore case sensitive and encoded in UTF-8 [RFC3629](https://www.rfc-editor.org/rfc/rfc3629).
 
 ## Terminology
 
@@ -107,7 +107,7 @@ The id of a record is immutable and assigned by the server. The id MUST be uniqu
 
 ## The JMAP API Model
 
-JMAP uses HTTP [@!RFC7230] to expose API, push, upload and download resources. All HTTP requests MUST use the `https://` scheme (HTTP over TLS [@!RFC2818]).
+JMAP uses HTTP [RFC7230](https://www.rfc-editor.org/rfc/rfc7230) to expose API, push, upload and download resources. All HTTP requests MUST use the `https://` scheme (HTTP over TLS [RFC2818](https://www.rfc-editor.org/rfc/rfc2818)).
 All HTTP requests MUST be authenticated.
 
 An authenticated client can fetch the user's Session object with details about the data and capabilities the server can provide as shown in Section 2. The client may then exchange data with the server in the following ways:

--- a/spec/jmap/push.mdown
+++ b/spec/jmap/push.mdown
@@ -65,12 +65,12 @@ A **PushSubscription** object has the following properties:
   An absolute URL where the JMAP server will POST the data for the push message.
   This MUST begin with `https://`.
 - **keys**: `Object|null` (immutable)
-  Client-generated encryption keys. If supplied, the server MUST use them as specified in [@!RFC8291] to encrypt all data sent to the push subscription. The object MUST have the following properties:
+  Client-generated encryption keys. If supplied, the server MUST use them as specified in [RFC8291](https://www.rfc-editor.org/rfc/rfc8291) to encrypt all data sent to the push subscription. The object MUST have the following properties:
 
-    - **p256dh**: `String`
-    The P-256 Elliptic Curve Diffie-Hellman (ECDH) public key as described in [@!RFC8291], encoded in URL-safe base64 representation as defined in [@!RFC4648].
-    - **auth**: `String`
-    The authentication secret as described in [@!RFC8291], encoded in URL-safe base64 representation as defined in [@!RFC4648].
+  - **p256dh**: `String`
+    The P-256 Elliptic Curve Diffie-Hellman (ECDH) public key as described in [RFC8291](https://www.rfc-editor.org/rfc/rfc8291), encoded in URL-safe base64 representation as defined in [RFC4648](https://www.rfc-editor.org/rfc/rfc4648).
+  - **auth**: `String`
+    The authentication secret as described in [RFC8291](https://www.rfc-editor.org/rfc/rfc8291), encoded in URL-safe base64 representation as defined in [RFC4648](https://www.rfc-editor.org/rfc/rfc4648).
 
 - **verificationCode**: `String|null`
   This MUST be `null` (or omitted) when the subscription is created. The JMAP server then generates a verification code and sends it in a push message, and the client updates the PushSubscription object with the code; see Section 7.2.2 for details.
@@ -82,17 +82,17 @@ A **PushSubscription** object has the following properties:
 - **types**: `String[]|null`
   A list of types the client is interested in (using the same names as the keys in the *TypeState* object defined in the previous section). A StateChange notification will only be sent if the data for one of these types changes. Other types are omitted from the TypeState object. If `null`, changes will be pushed for all types.
 
-The POST request MUST have a content type of `application/json` and contain the UTF-8 JSON-encoded object as the body. The request MUST have a `TTL` header and MAY have `Urgency` and/or `Topic` headers, as specified in Section 5 of [@!RFC8030]. The JMAP server is expected to understand and handle HTTP status responses in a reasonable manner. A `429` (Too Many Requests) response MUST cause the JMAP server to reduce the frequency of pushes; the JMAP push structure allows multiple changes to be coalesced into a single minimal StateChange object. See the security considerations in Section 8.6 for a discussion of the risks in connecting to unknown servers.
+The POST request MUST have a content type of `application/json` and contain the UTF-8 JSON-encoded object as the body. The request MUST have a `TTL` header and MAY have `Urgency` and/or `Topic` headers, as specified in Section 5 of [RFC8030](https://www.rfc-editor.org/rfc/rfc8030). The JMAP server is expected to understand and handle HTTP status responses in a reasonable manner. A `429` (Too Many Requests) response MUST cause the JMAP server to reduce the frequency of pushes; the JMAP push structure allows multiple changes to be coalesced into a single minimal StateChange object. See the security considerations in Section 8.6 for a discussion of the risks in connecting to unknown servers.
 
-The JMAP server acts as an application server as defined in [@!RFC8030]. A client MAY use the rest of [@!RFC8030] in combination with its own push service to form a complete end-to-end solution, or MAY rely on alternative mechanisms to ensure the delivery of the pushed data after it leaves the JMAP server.
+The JMAP server acts as an application server as defined in [RFC8030](https://www.rfc-editor.org/rfc/rfc8030). A client MAY use the rest of [RFC8030](https://www.rfc-editor.org/rfc/rfc8030) in combination with its own push service to form a complete end-to-end solution, or MAY rely on alternative mechanisms to ensure the delivery of the pushed data after it leaves the JMAP server.
 
 The push subscription is tied to the credentials used to authenticate the API request that created it. Should these credentials expire or be revoked, the push subscription MUST be destroyed by the JMAP server. Only subscriptions created by these credentials are returned when the client fetches existing subscriptions.
 
 When these credentials have their own expiry (i.e., it is a session with a timeout), the server SHOULD NOT set or bound the expiry time for the push subscription given by the client but MUST expire it when the session expires.
 
-When these credentials are not time bounded (e.g., Basic Authentication [@!RFC7617]), the server SHOULD set an expiry time for the push subscription if none is given and limit the expiry time if set too far in the future. This maximum expiry time MUST be at least 48 hours in the future and SHOULD be at least 7 days in the future. An app running on a mobile device may only be able to refresh the push subscription lifetime when it is in the foreground, so this gives a reasonable time frame to allow this to happen.
+When these credentials are not time bounded (e.g., Basic Authentication [RFC7617](https://www.rfc-editor.org/rfc/rfc7617)), the server SHOULD set an expiry time for the push subscription if none is given and limit the expiry time if set too far in the future. This maximum expiry time MUST be at least 48 hours in the future and SHOULD be at least 7 days in the future. An app running on a mobile device may only be able to refresh the push subscription lifetime when it is in the foreground, so this gives a reasonable time frame to allow this to happen.
 
-In the case of separate access and refresh credentials, as in Oauth 2.0 [@!RFC6749], the server SHOULD tie the push subscription to the validity of the refresh token rather than the access token and behave according to whether this is time-limited or not.
+In the case of separate access and refresh credentials, as in Oauth 2.0 [RFC6749](https://www.rfc-editor.org/rfc/rfc6749), the server SHOULD tie the push subscription to the validity of the refresh token rather than the access token and behave according to whether this is time-limited or not.
 
 When a push subscription is destroyed, the server MUST securely erase the URL and encryption keys from memory and storage as soon as possible.
 
@@ -225,7 +225,7 @@ When a change occurs in the data on the server, it pushes an event called `state
 
 The server SHOULD also send a new event id that encodes the entire server state visible to the user immediately after sending a *state* event. When a new connection is made to the event-source endpoint, a client following the server-sent events specification will send a Last-Event-ID HTTP header field with the last id it saw, which the server can use to work out whether the client has missed some changes. If so, it SHOULD send these changes immediately on connection.
 
-The Session object (see Section 2) has an *eventSourceUrl* property, which is in URI Template (level 1) format [@!RFC6570]. The URL MUST contain variables called `types`, `closeafter`, and `ping`.
+The Session object (see Section 2) has an *eventSourceUrl* property, which is in URI Template (level 1) format [RFC6570](https://www.rfc-editor.org/rfc/rfc6570). The URL MUST contain variables called `types`, `closeafter`, and `ping`.
 
 To connect to the resource, the client makes an authenticated GET request to the event-source URL with the appropriate variables substituted in:
 

--- a/spec/jmap/securityconsiderations.mdown
+++ b/spec/jmap/securityconsiderations.mdown
@@ -2,13 +2,13 @@
 
 ## Transport Confidentiality
 
-To ensure the confidentiality and integrity of data sent and received via JMAP, all requests MUST use TLS 1.2 [@!RFC5246] [@!RFC8446] or later, following the recommendations in [@!RFC7525]. Servers SHOULD support TLS 1.3 [@!RFC8446] or later.
+To ensure the confidentiality and integrity of data sent and received via JMAP, all requests MUST use TLS 1.2 [RFC5246](https://www.rfc-editor.org/rfc/rfc5246) [RFC8446](https://www.rfc-editor.org/rfc/rfc8446) or later, following the recommendations in [RFC7525](https://www.rfc-editor.org/rfc/rfc7525). Servers SHOULD support TLS 1.3 [RFC8446](https://www.rfc-editor.org/rfc/rfc8446) or later.
 
-Clients MUST validate TLS certificate chains to protect against man-in-the-middle attacks [@!RFC5280].
+Clients MUST validate TLS certificate chains to protect against man-in-the-middle attacks [RFC5280](https://www.rfc-editor.org/rfc/rfc5280).
 
 ## Authentication Scheme
 
-A number of HTTP authentication schemes have been standardised (see https://www.iana.org/assignments/http-authschemes/). Servers should take care to assess the security characteristics of different schemes in relation to their needs when deciding what to implement.
+A number of HTTP authentication schemes have been standardised (see <https://www.iana.org/assignments/http-authschemes/>). Servers should take care to assess the security characteristics of different schemes in relation to their needs when deciding what to implement.
 
 Use of the Basic authentication scheme is NOT RECOMMENDED. Services that choose to use it are strongly recommended to require generation of a unique "app password" via some external mechanism for each client they wish to connect. This allows connections from different devices to be differentiated by the server and access to be individually revoked.
 
@@ -21,7 +21,7 @@ Clients that do not support SRV lookups are likely to try just using the `/.well
 
 ## JSON Parsing
 
-The Security Considerations of [@!RFC8259] apply to the use of JSON as the data interchange format.
+The Security Considerations of [RFC8259](https://www.rfc-editor.org/rfc/rfc8259) apply to the use of JSON as the data interchange format.
 
 As for any serialization format, parsers need to thoroughly check the
 syntax of the supplied data. JSON uses opening and closing tags for
@@ -71,9 +71,9 @@ The server MUST limit the number of push subscriptions any one user may have to 
 
 When data changes, a small object is pushed with the new state strings for the types that have changed. While the data here is minimal, a passive man-in-the-middle attacker may be able to gain useful information. To ensure confidentiality and integrity, if the push is sent via a third party outside of the control of the client and JMAP server, the client MUST specify encryption keys when establishing the PushSubscription and ignore any push notification received that is not encrypted with those keys.
 
-The privacy and security considerations of [@!RFC8030] and [@!RFC8291] also apply to the use of the PushSubscription mechanism.
+The privacy and security considerations of [RFC8030](https://www.rfc-editor.org/rfc/rfc8030) and [RFC8291](https://www.rfc-editor.org/rfc/rfc8291) also apply to the use of the PushSubscription mechanism.
 
-As there is no crypto algorithm agility in Web Push Encryption [@!RFC8291], a new specification will be needed to provide this if new algorithms are required in the future.
+As there is no crypto algorithm agility in Web Push Encryption [RFC8291](https://www.rfc-editor.org/rfc/rfc8291), a new specification will be needed to provide this if new algorithms are required in the future.
 
 ## Traffic Analysis
 

--- a/spec/jmap/session.mdown
+++ b/spec/jmap/session.mdown
@@ -16,24 +16,24 @@ A successful authenticated GET request to the JMAP Session resource MUST return 
 
     The capabilities object MUST include a property called `urn:ietf:params:jmap:core`. The value of this property is an object that MUST contain the following information on server capabilities (suggested minimum values for limits are supplied that allow clients to make efficient use of the network):
 
-    - **maxSizeUpload**: `UnsignedInt`
+  - **maxSizeUpload**: `UnsignedInt`
       The maximum file size, in octets, that the server will accept for a single file upload (for any purpose). Suggested minimum: 50,000,000.
-    - **maxConcurrentUpload**: `UnsignedInt`
+  - **maxConcurrentUpload**: `UnsignedInt`
       The maximum number of concurrent requests the server will accept to the upload endpoint.  Suggested minimum: 4.
-    - **maxSizeRequest**: `UnsignedInt`
+  - **maxSizeRequest**: `UnsignedInt`
       The maximum size, in octets, that the server will accept for a single
       request to the API endpoint. Suggested minimum: 10,000,000.
-    - **maxConcurrentRequests**: `UnsignedInt`
+  - **maxConcurrentRequests**: `UnsignedInt`
       The maximum number of concurrent requests the server will accept to
       the API endpoint. Suggested minimum: 4.
-    - **maxCallsInRequest**: `UnsignedInt`
+  - **maxCallsInRequest**: `UnsignedInt`
       The maximum number of method calls the server will accept in a single request to the API endpoint.  Suggested minimum: 16.
-    - **maxObjectsInGet**: `UnsignedInt`
+  - **maxObjectsInGet**: `UnsignedInt`
       The maximum number of objects that the client may request in a single `/get` type method call. Suggested minimum: 500.
-    - **maxObjectsInSet**: `UnsignedInt`
+  - **maxObjectsInSet**: `UnsignedInt`
       The maximum number of objects the client may send to create, update, or destroy in a single `/set` type method call. This is the combined total, e.g., if the maximum is 10, you could not create 7 objects and destroy 6, as this would be 13 actions, which exceeds the limit. Suggested minimum: 500.
-    - **collationAlgorithms**: `String[]`
-      A list of identifiers for algorithms registered in the collation registry, as defined in [@!RFC4790], that the server supports for sorting when querying records.
+  - **collationAlgorithms**: `String[]`
+      A list of identifiers for algorithms registered in the collation registry, as defined in [RFC4790](https://www.rfc-editor.org/rfc/rfc4790), that the server supports for sorting when querying records.
 
     Specifications for future capabilities will define their own properties on the capabilities object.
 
@@ -42,13 +42,13 @@ A successful authenticated GET request to the JMAP Session resource MUST return 
 - **accounts**: `Id[Account]`
   A map of an **account id** to an Account object for each account (see Section 1.6.2) the user has access to. An **Account** object has the following properties:
 
-    - **name**: `String`
+  - **name**: `String`
       A user-friendly string to show when presenting content from this account, e.g., the email address representing the owner of the account.
-    - **isPersonal**: `Boolean`
+  - **isPersonal**: `Boolean`
       This is `true` if the account belongs to the authenticated user rather than a group account or a personal account of another user that has been shared with them.
-    - **isReadOnly**: `Boolean`
+  - **isReadOnly**: `Boolean`
       This is `true` if the entire account is read-only.
-    - **accountCapabilities**: `String[Object]`
+  - **accountCapabilities**: `String[Object]`
       The set of capability URIs for the methods supported in this account. Each key is a URI for a capability that has methods you can use with this account. The value for each of these keys is an object with further information about the account's permissions and restrictions with respect to this capability, as defined in the capability's specification.
 
         The client MUST ignore any properties it does not understand.
@@ -80,11 +80,11 @@ A successful authenticated GET request to the JMAP Session resource MUST return 
 - **apiUrl**: `String`
   The URL to use for JMAP API requests.
 - **downloadUrl**: `String`
-  The URL endpoint to use when downloading files, in URI Template (level 1) format [@!RFC6570]. The URL MUST contain variables called `accountId`, `blobId`, `type`, and `name`. The use of these variables is described in Section 6.2. Due to potential encoding issues with slashes in content types, it is RECOMMENDED to put the `type` variable in the query section of the URL.
+  The URL endpoint to use when downloading files, in URI Template (level 1) format [RFC6570](https://www.rfc-editor.org/rfc/rfc6570). The URL MUST contain variables called `accountId`, `blobId`, `type`, and `name`. The use of these variables is described in Section 6.2. Due to potential encoding issues with slashes in content types, it is RECOMMENDED to put the `type` variable in the query section of the URL.
 - **uploadUrl**: `String`
-  The URL endpoint to use when uploading files, in URI Template (level 1) format [@!RFC6570]. The URL MUST contain a variable called `accountId`. The use of this variable is described in Section 6.1.
+  The URL endpoint to use when uploading files, in URI Template (level 1) format [RFC6570](https://www.rfc-editor.org/rfc/rfc6570). The URL MUST contain a variable called `accountId`. The use of this variable is described in Section 6.1.
 - **eventSourceUrl**: `String`
-  The URL to connect to for push events, as described in Section 7.3, in URI Template (level 1) format [@!RFC6570]. The URL MUST contain variables called `types`, `closeafter`, and `ping`. The use of these variables is described in Section 7.3.
+  The URL to connect to for push events, as described in Section 7.3, in URI Template (level 1) format [RFC6570](https://www.rfc-editor.org/rfc/rfc6570). The URL MUST contain variables called `types`, `closeafter`, and `ping`. The use of these variables is described in Section 7.3.
 - **state**: `String`
   A (preferably short) string representing the state of this object on the server. If the value of any other property on the Session object changes, this string will change. The current value is also returned on the API Response object (see Section 3.4), allowing clients to quickly determine if the session information has changed (e.g., an account has been added or removed), so they need to refetch the object.
 
@@ -165,8 +165,8 @@ In the following example Session object, the user has access to their own mail a
 
 There are two standardised autodiscovery methods in use for Internet protocols:
 
-- **DNS SRV** (see [@!RFC2782], [@!RFC6186], and [@!RFC6764])
-- **.well-known/servicename** (see [@!RFC8615])
+- **DNS SRV** (see [RFC2782](https://www.rfc-editor.org/rfc/rfc2782), [RFC6186](https://www.rfc-editor.org/rfc/rfc6186), and [RFC6764](https://www.rfc-editor.org/rfc/rfc6764))
+- **.well-known/servicename** (see [RFC8615](https://www.rfc-editor.org/rfc/rfc8615))
 
 A JMAP-supporting host for the domain `example.com` SHOULD publish a SRV record `_jmap._tcp.example.com` that gives a *hostname* and *port* (usually port `443`). The JMAP Session resource is then `https://${hostname}[:${port}]/.well-known/jmap` (following any redirects).
 

--- a/spec/mail/ianaconsiderations.mdown
+++ b/spec/mail/ianaconsiderations.mdown
@@ -44,7 +44,7 @@ Security and privacy considerations: this document, Section 9
 
 ## IMAP and JMAP Keywords Registry
 
-This document makes two changes to the IMAP keywords registry as defined in [@!RFC5788].
+This document makes two changes to the IMAP keywords registry as defined in [RFC5788](https://www.rfc-editor.org/rfc/rfc5788).
 
 First, the name of the registry is changed to the "IMAP and JMAP Keywords" registry.
 
@@ -262,7 +262,7 @@ Owner/Change controller: IESG
 
 ### Registration of "inbox" Role
 
-This registers the "JMAP-only" `inbox` attribute in the "IMAP Mailbox Name Attributes" registry, as established in [@!RFC8457].
+This registers the "JMAP-only" `inbox` attribute in the "IMAP Mailbox Name Attributes" registry, as established in [RFC8457](https://www.rfc-editor.org/rfc/rfc8457).
 
 Attribute Name: Inbox
 
@@ -274,7 +274,7 @@ Usage Notes: JMAP only
 
 ## JMAP Error Codes Registry
 
-The following subsections register several new error codes in the "JMAP Error Codes" registry, as defined in [@!RFC8620].
+The following subsections register several new error codes in the "JMAP Error Codes" registry, as defined in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620).
 
 ### mailboxHasChild
 
@@ -358,7 +358,7 @@ Change controller: IETF
 
 Reference: This document, Section 7.5
 
-Description: The envelope [@!RFC5321]  (supplied or generated) has more recipients than the server allows.
+Description: The envelope [RFC5321](https://www.rfc-editor.org/rfc/rfc5321)  (supplied or generated) has more recipients than the server allows.
 
 ### noRecipients
 
@@ -370,7 +370,7 @@ Change controller: IETF
 
 Reference: This document, Section 7.5
 
-Description: The envelope [@!RFC5321]  (supplied or generated) does not have any rcptTo email addresses.
+Description: The envelope [RFC5321](https://www.rfc-editor.org/rfc/rfc5321)  (supplied or generated) does not have any rcptTo email addresses.
 
 ### invalidRecipients
 
@@ -382,7 +382,7 @@ Change controller: IETF
 
 Reference: This document, Section 7.5
 
-Description:  The rcptTo property of the envelope [@!RFC5321]  (supplied or generated) contains at least one rcptTo value that is not a valid email address for sending to.
+Description:  The rcptTo property of the envelope [RFC5321](https://www.rfc-editor.org/rfc/rfc5321)  (supplied or generated) contains at least one rcptTo value that is not a valid email address for sending to.
 
 ### forbiddenMailFrom
 
@@ -394,7 +394,7 @@ Change controller: IETF
 
 Reference: This document, Section 7.5
 
-Description: – The server does not permit the user to send a message with this envelope From address [@!RFC5321].
+Description: – The server does not permit the user to send a message with this envelope From address [RFC5321](https://www.rfc-editor.org/rfc/rfc5321).
 
 ### forbiddenFrom
 
@@ -406,7 +406,7 @@ Change controller: IETF
 
 Reference: This document, sections 6.3 and 7.5
 
-Description: The server does not permit the user to send a message with the From header field [@!RFC5322] of the message to be sent.
+Description: The server does not permit the user to send a message with the From header field [RFC5322](https://www.rfc-editor.org/rfc/rfc5322) of the message to be sent.
 
 ### forbiddenToSend
 

--- a/spec/mail/identity.mdown
+++ b/spec/mail/identity.mdown
@@ -27,15 +27,15 @@ The following JMAP methods are supported.
 
 ## Identity/get
 
-This is a standard "/get" method as described in [@!RFC8620], Section 5.1. The *ids* argument may be `null` to fetch all at once.
+This is a standard "/get" method as described in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 5.1. The *ids* argument may be `null` to fetch all at once.
 
 ## Identity/changes
 
-This is a standard "/changes" method as described in [@!RFC8620], Section 5.2.
+This is a standard "/changes" method as described in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 5.2.
 
 ## Identity/set
 
-This is a standard "/set" method as described in [@!RFC8620], Section 5.3. The following extra *SetError* types are defined:
+This is a standard "/set" method as described in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 5.3. The following extra *SetError* types are defined:
 
 For **create**:
 

--- a/spec/mail/intro.mdown
+++ b/spec/mail/intro.mdown
@@ -1,6 +1,6 @@
 # Introduction
 
-The JSON Meta Application Protocol (JMAP) [@!RFC8620] is a generic protocol for synchronising data, such as mail, calendars, or contacts between a client and a server. It is optimised for mobile and web environments and aims to provide a consistent interface to different data types.
+The JSON Meta Application Protocol (JMAP) [RFC8620](https://www.rfc-editor.org/rfc/rfc8620) is a generic protocol for synchronising data, such as mail, calendars, or contacts between a client and a server. It is optimised for mobile and web environments and aims to provide a consistent interface to different data types.
 
 This specification defines a data model for accessing a mail store over JMAP,
 allowing you to query, read, organise, and submit mail for sending.
@@ -28,9 +28,9 @@ user's inbox has been shared as read-only with them.
 
 ## Notational Conventions
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in BCP 14 [@!RFC2119] [@!RFC8174] when, and only when, they appear in all capitals, as shown here.
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in BCP 14 [RFC2119](https://www.rfc-editor.org/rfc/rfc2119) [RFC8174](https://www.rfc-editor.org/rfc/rfc8174) when, and only when, they appear in all capitals, as shown here.
 
-Type signatures, examples, and property descriptions in this document follow the conventions established in Section 1.1 of [@!RFC8620]. Data types defined in the core specification are also used in this document.
+Type signatures, examples, and property descriptions in this document follow the conventions established in Section 1.1 of [RFC8620](https://www.rfc-editor.org/rfc/rfc8620). Data types defined in the core specification are also used in this document.
 
 Servers MUST support all properties specified for the new data types defined in this document.
 
@@ -40,11 +40,11 @@ This document uses the same terminology as in the core JMAP specification.
 
 The terms Mailbox, Thread, Email, SearchSnippet, EmailSubmission and VacationResponse (with that specific capitalisation) are used to refer to the data types defined in this document and instances of those data types.
 
-The term message refers to a document in Internet Message Format, as described in [@!RFC5322]. The Email data type represents messages in the mail store and associated metadata.
+The term message refers to a document in Internet Message Format, as described in [RFC5322](https://www.rfc-editor.org/rfc/rfc5322). The Email data type represents messages in the mail store and associated metadata.
 
 ## Additions to the Capabilities Object
 
-The capabilities object is returned as part of the JMAP Session object; see [@!RFC8620], Section 2.
+The capabilities object is returned as part of the JMAP Session object; see [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 2.
 
 This document defines three additional capability URIs.
 
@@ -65,7 +65,7 @@ The value of this property in an account's *accountCapabilities* property is an 
 
     Note that this limit is for the sum of unencoded attachment sizes. Users are generally not knowledgeable about encoding overhead, etc., nor should they need to be, so marketing and help materials normally tell them the "max size attachments". This is the unencoded size they see on their hard drive, so this capability matches that and allows the client to consistently enforce what the user understands as the limit.
 
-    The server may separately have a limit for the total size of the message [@!RFC5322], created by combining the attachments (often base64 encoded) with the message headers and bodies. For example, suppose the server advertises `maxSizeAttachmentsPerEmail: 50000000` (50 MB). The enforced server limit may be for a message size of 70000000 octets. Even with base64 encoding and a 2 MB HTML body, 50 MB attachments would fit under this limit.
+    The server may separately have a limit for the total size of the message [RFC5322](https://www.rfc-editor.org/rfc/rfc5322), created by combining the attachments (often base64 encoded) with the message headers and bodies. For example, suppose the server advertises `maxSizeAttachmentsPerEmail: 50000000` (50 MB). The enforced server limit may be for a message size of 70000000 octets. Even with base64 encoding and a 2 MB HTML body, 50 MB attachments would fit under this limit.
 
 - **emailQuerySortOptions**: `String[]`
   A list of all the values the server supports for the "property" field of the Comparator object in an Email/query sort (see Section 4.4.2). This MAY include properties the client does not recognise (for example, custom properties specified in a vendor extension). Clients MUST ignore any unknown properties in the list.
@@ -86,15 +86,15 @@ The value of this property in an account's *accountCapabilities* property is an 
 - **submissionExtensions**: `String[String[]]`
   The set of SMTP submission extensions supported by the server, which the client may use when creating an EmailSubmission object (see Section 7). Each key in the object is the *ehlo-name*, and the value is a list of *ehlo-args*.
 
-    A JMAP implementation that talks to a submission server [@!RFC6409] SHOULD have a configuration setting that allows an administrator to modify the set of submission EHLO capabilities it may expose on this property. This allows a JMAP server to easily add access to a new submission extension without code changes. By default, the JMAP server should hide EHLO capabilities that have to do with the transport mechanism and thus are only relevant to the JMAP server (for example, PIPELINING, CHUNKING, or STARTTLS).
+    A JMAP implementation that talks to a submission server [RFC6409](https://www.rfc-editor.org/rfc/rfc6409) SHOULD have a configuration setting that allows an administrator to modify the set of submission EHLO capabilities it may expose on this property. This allows a JMAP server to easily add access to a new submission extension without code changes. By default, the JMAP server should hide EHLO capabilities that have to do with the transport mechanism and thus are only relevant to the JMAP server (for example, PIPELINING, CHUNKING, or STARTTLS).
 
     Examples of Submission extensions to include:
 
-    - FUTURERELEASE [@!RFC4865]
-    - SIZE [@!RFC1870]
-    - DSN [@!RFC3461]
-    - DELIVERYBY [@!RFC2852]
-    - MT-PRIORITY [@!RFC6710]
+  - FUTURERELEASE [RFC4865](https://www.rfc-editor.org/rfc/rfc4865)
+  - SIZE [RFC1870](https://www.rfc-editor.org/rfc/rfc1870)
+  - DSN [RFC3461](https://www.rfc-editor.org/rfc/rfc3461)
+  - DELIVERYBY [RFC2852](https://www.rfc-editor.org/rfc/rfc2852)
+  - MT-PRIORITY [RFC6710](https://www.rfc-editor.org/rfc/rfc6710)
 
     A JMAP server MAY advertise an extension and implement the semantics of that extension locally on the JMAP server even if a submission server used by JMAP doesn't implement it.
 
@@ -111,7 +111,7 @@ The server MUST include the appropriate capability strings as keys in the *accou
 
 ## Push
 
-Servers MUST support the JMAP push mechanisms, as specified in [@!RFC8620] Section 7, to receive notifications when the state changes for any of the types defined in this specification.
+Servers MUST support the JMAP push mechanisms, as specified in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620) Section 7, to receive notifications when the state changes for any of the types defined in this specification.
 
 In addition, servers that implement the "urn:ietf:params:jmap:mail" capability MUST support pushing state changes for a type called "EmailDelivery". There are no methods to act on this type; it only exists as part of the push mechanism. The state string for this MUST change whenever a new Email is added to the store, but it SHOULD NOT change upon any other change to the Email objects, for example, if one is marked as read or deleted.
 
@@ -119,8 +119,8 @@ Clients in battery-constrained environments may wish to delay fetching changes i
 
 ### Example
 
-The client has registered for push notifications (see [@!RFC8620]) just for the `EmailDelivery` type. The user marks an Email as read on another device, causing the state string for the `Email` type to change; however, as nothing new was added to the store, the `EmailDelivery` state does not change and nothing is pushed to the client. A new message arrives in the user's inbox, again causing the `Email` state to change. This time, the `EmailDelivery` state also changes, and a StateChange object is pushed to the client with the new state string. The client may then resync to fetch the new Email immediately.
+The client has registered for push notifications (see [RFC8620](https://www.rfc-editor.org/rfc/rfc8620)) just for the `EmailDelivery` type. The user marks an Email as read on another device, causing the state string for the `Email` type to change; however, as nothing new was added to the store, the `EmailDelivery` state does not change and nothing is pushed to the client. A new message arrives in the user's inbox, again causing the `Email` state to change. This time, the `EmailDelivery` state also changes, and a StateChange object is pushed to the client with the new state string. The client may then resync to fetch the new Email immediately.
 
 ## Ids
 
-If a JMAP Mail server also provides an IMAP interface to the data and supports IMAP Extension for Object Identifiers [@!RFC8474], the ids SHOULD be the same for Mailbox, Thread, and Email objects in JMAP.
+If a JMAP Mail server also provides an IMAP interface to the data and supports IMAP Extension for Object Identifiers [RFC8474](https://www.rfc-editor.org/rfc/rfc8474), the ids SHOULD be the same for Mailbox, Thread, and Email objects in JMAP.

--- a/spec/mail/mailbox.mdown
+++ b/spec/mail/mailbox.mdown
@@ -9,15 +9,15 @@ A **Mailbox** object has the following properties:
 - **id**: `Id` (immutable; server-set)
   The id of the Mailbox.
 - **name**: `String`
-  User-visible name for the Mailbox, e.g., "Inbox". This MUST be a Net-Unicode string [@!RFC5198] of at least 1 character in length, subject to the maximum size given in the capability object. There MUST NOT be two sibling Mailboxes with both the same parent and the same name. Servers MAY reject names that violate server policy (e.g., names containing a slash (/) or control characters).
+  User-visible name for the Mailbox, e.g., "Inbox". This MUST be a Net-Unicode string [RFC5198](https://www.rfc-editor.org/rfc/rfc5198) of at least 1 character in length, subject to the maximum size given in the capability object. There MUST NOT be two sibling Mailboxes with both the same parent and the same name. Servers MAY reject names that violate server policy (e.g., names containing a slash (/) or control characters).
 - **parentId**: `Id|null` (default: null)
   The Mailbox id for the parent of this Mailbox, or `null` if this Mailbox is at the top level. Mailboxes form acyclic graphs (forests) directed by the child-to-parent relationship. There MUST NOT be a loop.
 - **role**: `String|null` (default: null)
   Identifies Mailboxes that have a particular common purpose (e.g., the "inbox"), regardless of the *name* property (which may be localised).
 
-    This value is shared with IMAP (exposed in IMAP via the SPECIAL-USE extension [@!RFC6154]). However, unlike in IMAP, a Mailbox MUST only have a single role, and there MUST NOT be two Mailboxes in the same account with the same role. Servers providing IMAP access to the same data are encouraged to enforce these extra restrictions in IMAP as well. Otherwise, modifying the IMAP attributes to ensure compliance when exposing the data over JMAP is implementation dependent.
+    This value is shared with IMAP (exposed in IMAP via the SPECIAL-USE extension [RFC6154](https://www.rfc-editor.org/rfc/rfc6154)). However, unlike in IMAP, a Mailbox MUST only have a single role, and there MUST NOT be two Mailboxes in the same account with the same role. Servers providing IMAP access to the same data are encouraged to enforce these extra restrictions in IMAP as well. Otherwise, modifying the IMAP attributes to ensure compliance when exposing the data over JMAP is implementation dependent.
 
-    The value MUST be one of the Mailbox attribute names listed in the [IANA IMAP Mailbox Name Attributes](https://www.iana.org/assignments/imap-mailbox-name-attributes/imap-mailbox-name-attributes.xhtml) registry, as established in [@!RFC8457], converted to lowercase. New roles may be established here in the future.
+    The value MUST be one of the Mailbox attribute names listed in the [IANA IMAP Mailbox Name Attributes](https://www.iana.org/assignments/imap-mailbox-name-attributes/imap-mailbox-name-attributes.xhtml) registry, as established in [RFC8457](https://www.rfc-editor.org/rfc/rfc8457), converted to lowercase. New roles may be established here in the future.
 
     An account is not required to have Mailboxes with any particular roles.
 
@@ -50,25 +50,25 @@ A **Mailbox** object has the following properties:
     For example, suppose you have an account where the entire contents is a single Thread with 2 Emails: an unread Email in the trash and a read Email in the inbox. The `unreadThreads` count would be `1` for the trash and `0` for the inbox.
 
 - **myRights**: `MailboxRights` (server-set)
-  The set of rights (Access Control Lists (ACLs)) the user has in relation to this Mailbox. These are backwards compatible with IMAP ACLs, as defined in [@!RFC4314]. A **MailboxRights** object has the following properties:
+  The set of rights (Access Control Lists (ACLs)) the user has in relation to this Mailbox. These are backwards compatible with IMAP ACLs, as defined in [RFC4314](https://www.rfc-editor.org/rfc/rfc4314). A **MailboxRights** object has the following properties:
 
-    - **mayReadItems**: `Boolean`
+  - **mayReadItems**: `Boolean`
       If true, the user may use this Mailbox as part of a filter in an *Email/query* call, and the Mailbox may be included in the *mailboxIds* property of Email objects. Email objects may be fetched if they are in **at least one** Mailbox with this permission. If a sub-Mailbox is shared but not the parent Mailbox, this may be `false`. Corresponds to IMAP ACLs `lr` (if mapping from IMAP, both are required for this to be `true`).
-    - **mayAddItems**: `Boolean`
+  - **mayAddItems**: `Boolean`
       The user may add mail to this Mailbox (by either creating a new Email or moving an existing one). Corresponds to IMAP ACL `i`.
-    - **mayRemoveItems**: `Boolean`
+  - **mayRemoveItems**: `Boolean`
       The user may remove mail from this Mailbox (by either changing the Mailboxes of an Email or destroying the Email). Corresponds to IMAP ACLs `te` (if mapping from IMAP, both are required for this to be `true`).
-    - **maySetSeen**: `Boolean`
+  - **maySetSeen**: `Boolean`
       The user may add or remove the `$seen` keyword to/from an Email. If an Email belongs to multiple Mailboxes, the user may only modify `$seen` if they have this permission for **all** of the Mailboxes. Corresponds to IMAP ACL `s`.
-    - **maySetKeywords**: `Boolean`
+  - **maySetKeywords**: `Boolean`
       The user may add or remove any keyword *other than* `$seen` to/from an Email. If an Email belongs to multiple Mailboxes, the user may only modify keywords if they have this permission for **all** of the Mailboxes. Corresponds to IMAP ACL `w`.
-    - **mayCreateChild**: `Boolean`
+  - **mayCreateChild**: `Boolean`
       The user may create a Mailbox with this Mailbox as its parent. Corresponds to IMAP ACL `k`.
-    - **mayRename**: `Boolean`
+  - **mayRename**: `Boolean`
       The user may rename the Mailbox or make it a child of another Mailbox. Corresponds to IMAP ACL `x` (although this covers both rename and delete permissions).
-    - **mayDelete**: `Boolean`
+  - **mayDelete**: `Boolean`
       The user may delete the Mailbox itself. Corresponds to IMAP ACL `x` (although this covers both rename and delete permissions).
-    - **maySubmit**: `Boolean`
+  - **maySubmit**: `Boolean`
       Messages may be submitted directly to this Mailbox. Corresponds to IMAP ACL `p`.
 
 - **isSubscribed**: `Boolean`
@@ -84,11 +84,11 @@ The following JMAP methods are supported.
 
 ## Mailbox/get
 
-This is a standard "/get" method as described in [@!RFC8620], Section 5.1. The *ids* argument may be `null` to fetch all at once.
+This is a standard "/get" method as described in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 5.1. The *ids* argument may be `null` to fetch all at once.
 
 ## Mailbox/changes
 
-This is a standard "/changes" method as described in [@!RFC8620], Section 5.2 but with one extra argument to the response:
+This is a standard "/changes" method as described in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 5.2 but with one extra argument to the response:
 
 - **updatedProperties**: `String[]|null`
   If only the "totalEmails", "unreadEmails", "totalThreads", and/or "unreadThreads" Mailbox properties have changed since the old state, this will be the list of properties that may have changed. If the server is unable to tell if only counts have changed, it MUST just be `null`.
@@ -97,15 +97,15 @@ Since counts frequently change but other properties are generally only changed r
 
 ## Mailbox/query
 
-This is a standard "/query" method as described in [@!RFC8620], Section 5.5, but with the following additional request argument:
+This is a standard "/query" method as described in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 5.5, but with the following additional request argument:
 
 - **sortAsTree**: `Boolean` (default: false)
   If `true`, when sorting the query results and comparing Mailboxes A and B:
 
-    - If A is an ancestor of B, it always comes first regardless of the *sort*
+  - If A is an ancestor of B, it always comes first regardless of the *sort*
       comparators. Similarly, if A is descendant of B, then B always comes
       first.
-    - Otherwise, if A and B do not share a *parentId*, find the nearest
+  - Otherwise, if A and B do not share a *parentId*, find the nearest
       ancestors of each that do have the same *parentId* and compare the sort
       properties on those Mailboxes instead.
 
@@ -136,11 +136,11 @@ The following Mailbox properties MUST be supported for sorting:
 
 ## Mailbox/queryChanges
 
-This is a standard "/queryChanges" method as described in [@!RFC8620], Section 5.6.
+This is a standard "/queryChanges" method as described in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 5.6.
 
 ## Mailbox/set
 
-This is a standard "/set" method as described in [@!RFC8620], Section 5.3, but with the following additional request argument:
+This is a standard "/set" method as described in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 5.3, but with the following additional request argument:
 
 - **onDestroyRemoveEmails**: `Boolean` (default: false)
   If `false`, any attempt to destroy a Mailbox that still has Emails in it will be rejected with a `mailboxHasEmail` SetError. If `true`, any Emails that were in the Mailbox will be removed from it, and if in no other Mailboxes, they will be destroyed when the Mailbox is destroyed.

--- a/spec/mail/message.mdown
+++ b/spec/mail/message.mdown
@@ -1,6 +1,6 @@
 # Emails
 
-An **Email** object is a representation of a message [@!RFC5322], which allows clients to avoid the complexities of MIME parsing, transfer encoding, and character encoding.
+An **Email** object is a representation of a message [RFC5322](https://www.rfc-editor.org/rfc/rfc5322), which allows clients to avoid the complexities of MIME parsing, transfer encoding, and character encoding.
 
 ## Properties of the Email Object
 
@@ -29,9 +29,9 @@ Due to the number of properties involved, the set of *Email* properties is speci
 These properties represent metadata about the message in the mail store and are not derived from parsing the message itself.
 
 - **id**: `Id` (immutable; server-set)
-  The id of the Email object. Note that this is the JMAP object id, NOT the Message-ID header field value of the message [@!RFC5322].
+  The id of the Email object. Note that this is the JMAP object id, NOT the Message-ID header field value of the message [RFC5322](https://www.rfc-editor.org/rfc/rfc5322).
 - **blobId**: `Id` (immutable; server-set)
-  The id representing the raw octets of the message [@!RFC5322] for this Email. This may be used to download the raw original message or to attach it directly to another Email, etc.
+  The id representing the raw octets of the message [RFC5322](https://www.rfc-editor.org/rfc/rfc5322) for this Email. This may be used to download the raw original message or to attach it directly to another Email, etc.
 - **threadId**: `Id` (immutable; server-set)
   The id of the Thread to which this Email belongs.
 - **mailboxIds**: `Id[Boolean]`
@@ -41,10 +41,10 @@ These properties represent metadata about the message in the mail store and are 
 
     Keywords are shared with IMAP. The six system keywords from IMAP get special treatment. The following four keywords have their first character changed from `\` in IMAP to `$` in JMAP and have particular semantic meaning:
 
-    - `$draft`: The Email is a draft the user is composing.
-    - `$seen`: The Email has been read.
-    - `$flagged`: The Email has been flagged for urgent/special attention.
-    - `$answered`: The Email has been replied to.
+  - `$draft`: The Email is a draft the user is composing.
+  - `$seen`: The Email has been read.
+  - `$flagged`: The Email has been flagged for urgent/special attention.
+  - `$answered`: The Email has been replied to.
 
     The IMAP `\Recent` keyword is not exposed via JMAP. The IMAP `\Deleted` keyword is also not present: IMAP uses a delete+expunge model, which JMAP does not. Any message with the `\Deleted` keyword MUST NOT be visible via JMAP (and so are not counted in the "totalEmails", "unreadEmails", "totalThreads", and "unreadThreads" Mailbox properties).
 
@@ -54,21 +54,21 @@ These properties represent metadata about the message in the mail store and are 
 
     Because JSON is case sensitive, servers MUST return keywords in lowercase.
 
-    The [IMAP and JMAP Keywords](https://www.iana.org/assignments/imap-jmap-keywords/) registry as established in [@!RFC5788] assigns semantic meaning to some other keywords in common use. New keywords may be established here in the future. In particular, note:
+    The [IMAP and JMAP Keywords](https://www.iana.org/assignments/imap-jmap-keywords/) registry as established in [RFC5788](https://www.rfc-editor.org/rfc/rfc5788) assigns semantic meaning to some other keywords in common use. New keywords may be established here in the future. In particular, note:
 
-    - `$forwarded`: The Email has been forwarded.
-    - `$phishing`: The Email is highly likely to be phishing. Clients SHOULD warn users to take care when viewing this Email and disable links and attachments.
-    - `$junk`: The Email is definitely spam. Clients SHOULD set this flag when users report spam to help train automated spam-detection systems.
-    - `$notjunk`: The Email is definitely not spam. Clients SHOULD set this flag when users indicate an Email is legitimate, to help train automated spam-detection systems.
+  - `$forwarded`: The Email has been forwarded.
+  - `$phishing`: The Email is highly likely to be phishing. Clients SHOULD warn users to take care when viewing this Email and disable links and attachments.
+  - `$junk`: The Email is definitely spam. Clients SHOULD set this flag when users report spam to help train automated spam-detection systems.
+  - `$notjunk`: The Email is definitely not spam. Clients SHOULD set this flag when users indicate an Email is legitimate, to help train automated spam-detection systems.
 
 - **size**: `UnsignedInt` (immutable; server-set)
-  The size, in octets, of the raw data for the message [@!RFC5322]  (as referenced by the *blobId*, i.e., the number of octets in the file the user would download).
+  The size, in octets, of the raw data for the message [RFC5322](https://www.rfc-editor.org/rfc/rfc5322)  (as referenced by the *blobId*, i.e., the number of octets in the file the user would download).
 - **receivedAt**: `UTCDate` (immutable; default: time of creation on server)
   The date the Email was received by the message store. This is the *internal date* in IMAP [@?RFC3501].
 
 ### Header Fields Parsed Forms
 
-Header field properties are derived from the message header fields [@!RFC5322]  [@!RFC6532]. All header fields may be fetched in a raw form. Some header fields may also be fetched in a parsed form. The structured form that may be fetched depends on the header. The forms are defined in the subsections that follow.
+Header field properties are derived from the message header fields [RFC5322](https://www.rfc-editor.org/rfc/rfc5322)  [RFC6532](https://www.rfc-editor.org/rfc/rfc6532). All header fields may be fetched in a raw form. Some header fields may also be fetched in a parsed form. The structured form that may be fetched depends on the header. The forms are defined in the subsections that follow.
 
 #### Raw
 
@@ -85,11 +85,11 @@ Type: `String`
 
 The header field value with:
 
-1. White space unfolded (as defined in [@!RFC5322], Section 2.2.3).
+1. White space unfolded (as defined in [RFC5322](https://www.rfc-editor.org/rfc/rfc5322), Section 2.2.3).
 2. The terminating CRLF at the end of the value removed.
 3. Any SP characters at the beginning of the value removed.
-4. Any syntactically correct encoded sections [@!RFC2047] with a known
-   character set decoded. Any NUL octets or control characters encoded per [@!RFC2047] are dropped from the decoded value. Any text that looks like syntax per [@!RFC2047] but violates placement or white space rules per [@!RFC2047] MUST NOT be decoded.
+4. Any syntactically correct encoded sections [RFC2047](https://www.rfc-editor.org/rfc/rfc2047) with a known
+   character set decoded. Any NUL octets or control characters encoded per [RFC2047](https://www.rfc-editor.org/rfc/rfc2047) are dropped from the decoded value. Any text that looks like syntax per [RFC2047](https://www.rfc-editor.org/rfc/rfc2047) but violates placement or white space rules per [RFC2047](https://www.rfc-editor.org/rfc/rfc2047) MUST NOT be decoded.
 5. The resulting unicode converted to Normalization Form C (NFC) form.
 
 If any decodings fail, the parser SHOULD insert a unicode replacement
@@ -97,22 +97,22 @@ character (U+FFFD) and attempt to continue as much as possible.
 
 To prevent obviously nonsense behaviour, which can lead to interoperability issues, this form may only be fetched or set for the following header fields:
 
-* Subject
-* Comments
-* Keywords
-* List-Id
-* Any header field not defined in [@!RFC5322] or [@!RFC2369]
+- Subject
+- Comments
+- Keywords
+- List-Id
+- Any header field not defined in [RFC5322](https://www.rfc-editor.org/rfc/rfc5322) or [RFC2369](https://www.rfc-editor.org/rfc/rfc2369)
 
 #### Addresses
 
 Type: `EmailAddress[]`
 
-The header field is parsed as an *address-list* value, as specified in [@!RFC5322], Section 3.4, into the `EmailAddress[]` type. There is an EmailAddress item for each *mailbox* parsed from the *address-list*. Group and comment information is discarded.
+The header field is parsed as an *address-list* value, as specified in [RFC5322](https://www.rfc-editor.org/rfc/rfc5322), Section 3.4, into the `EmailAddress[]` type. There is an EmailAddress item for each *mailbox* parsed from the *address-list*. Group and comment information is discarded.
 
 An **EmailAddress** object has the following properties:
 
 - **name**: `String|null`
-  The *display-name* of the *mailbox* [@!RFC5322]. If this is a *quoted-string*:
+  The *display-name* of the *mailbox* [RFC5322](https://www.rfc-editor.org/rfc/rfc5322). If this is a *quoted-string*:
 
     1. The surrounding DQUOTE characters are removed.
     2. Any *quoted-pair* is decoded.
@@ -122,9 +122,9 @@ An **EmailAddress** object has the following properties:
     If there is no *display-name* but there is a *comment* immediately following the *addr-spec*, the value of this SHOULD be used instead. Otherwise, this property is `null`.
 
 - **email**: `String`
-  The *addr-spec* of the *mailbox* [@!RFC5322].
+  The *addr-spec* of the *mailbox* [RFC5322](https://www.rfc-editor.org/rfc/rfc5322).
 
-Any syntactically correct encoded sections [@!RFC2047] with a known encoding MUST be decoded, following the same rules as for the *Text* form.
+Any syntactically correct encoded sections [RFC2047](https://www.rfc-editor.org/rfc/rfc2047) with a known encoding MUST be decoded, following the same rules as for the *Text* form.
 
 Parsing SHOULD be best effort in the face of invalid structure to
 accommodate invalid messages and semi-complete drafts. EmailAddress objects
@@ -146,35 +146,35 @@ would be parsed as:
 
 To prevent obviously nonsense behaviour, which can lead to interoperability issues, this form may only be fetched or set for the following header fields:
 
-* From
-* Sender
-* Reply-To
-* To
-* Cc
-* Bcc
-* Resent-From
-* Resent-Sender
-* Resent-Reply-To
-* Resent-To
-* Resent-Cc
-* Resent-Bcc
-* Any header field not defined in [@!RFC5322] or [@!RFC2369]
+- From
+- Sender
+- Reply-To
+- To
+- Cc
+- Bcc
+- Resent-From
+- Resent-Sender
+- Resent-Reply-To
+- Resent-To
+- Resent-Cc
+- Resent-Bcc
+- Any header field not defined in [RFC5322](https://www.rfc-editor.org/rfc/rfc5322) or [RFC2369](https://www.rfc-editor.org/rfc/rfc2369)
 
 #### GroupedAddresses
 
 Type: `EmailAddressGroup[]`
 
-This is similar to the Addresses form but preserves group information. The header field is parsed as an *address-list* value, as specified in [@!RFC5322], Section 3.4, into the `GroupedAddresses[]` type. Consecutive *mailbox* values that are not part of a group are still collected under an EmailAddressGroup object to provide a uniform type.
+This is similar to the Addresses form but preserves group information. The header field is parsed as an *address-list* value, as specified in [RFC5322](https://www.rfc-editor.org/rfc/rfc5322), Section 3.4, into the `GroupedAddresses[]` type. Consecutive *mailbox* values that are not part of a group are still collected under an EmailAddressGroup object to provide a uniform type.
 
 An **EmailAddressGroup** object has the following properties:
 
 - **name**: `String|null`
-  The *display-name* of the  *group* [@!RFC5322], or `null` if the addresses are not part of a group. If this is a *quoted-string*, it is processed the same as the *name* in the *EmailAddress* type.
+  The *display-name* of the  *group* [RFC5322](https://www.rfc-editor.org/rfc/rfc5322), or `null` if the addresses are not part of a group. If this is a *quoted-string*, it is processed the same as the *name* in the *EmailAddress* type.
 - **addresses**: `EmailAddress[]`
   The *mailbox* values that belong to this group, represented as EmailAddress
   objects.
 
-Any syntactically correct encoded sections [@!RFC2047] with a known encoding MUST be decoded, following the same rules as for the *Text* form.
+Any syntactically correct encoded sections [RFC2047](https://www.rfc-editor.org/rfc/rfc2047) with a known encoding MUST be decoded, following the same rules as for the *Text* form.
 
 Parsing SHOULD be best effort in the face of invalid structure to
 accommodate invalid messages and semi-complete drafts.
@@ -203,55 +203,55 @@ To prevent obviously nonsense behaviour, which can lead to interoperability issu
 
 Type: `String[]|null`
 
-The header field is parsed as a list of *msg-id* values, as specified in [@!RFC5322], Section 3.6.4, into the `String[]` type. Comments and/or folding white space (CFWS) and surrounding angle brackets (`<>`) are removed. If parsing fails, the value is `null`.
+The header field is parsed as a list of *msg-id* values, as specified in [RFC5322](https://www.rfc-editor.org/rfc/rfc5322), Section 3.6.4, into the `String[]` type. Comments and/or folding white space (CFWS) and surrounding angle brackets (`<>`) are removed. If parsing fails, the value is `null`.
 
 To prevent obviously nonsense behaviour, which can lead to interoperability issues, this form may only be fetched or set for the following header fields:
 
-* Message-ID
-* In-Reply-To
-* References
-* Resent-Message-ID
-* Any header field not defined in [@!RFC5322] or [@!RFC2369]
+- Message-ID
+- In-Reply-To
+- References
+- Resent-Message-ID
+- Any header field not defined in [RFC5322](https://www.rfc-editor.org/rfc/rfc5322) or [RFC2369](https://www.rfc-editor.org/rfc/rfc2369)
 
 #### Date
 
 Type: `Date|null`
 
-The header field is parsed as a *date-time* value, as specified in [@!RFC5322], Section 3.3, into the `Date` type. If parsing fails, the value is `null`.
+The header field is parsed as a *date-time* value, as specified in [RFC5322](https://www.rfc-editor.org/rfc/rfc5322), Section 3.3, into the `Date` type. If parsing fails, the value is `null`.
 
 To prevent obviously nonsense behaviour, which can lead to interoperability issues, this form may only be fetched or set for the following header fields:
 
-* Date
-* Resent-Date
-* Any header field not defined in [@!RFC5322] or [@!RFC2369]
+- Date
+- Resent-Date
+- Any header field not defined in [RFC5322](https://www.rfc-editor.org/rfc/rfc5322) or [RFC2369](https://www.rfc-editor.org/rfc/rfc2369)
 
 #### URLs
 
 Type: `String[]|null`
 
-The header field is parsed as a list of URLs, as described in [@!RFC2369], into the `String[]` type. Values do not include the surrounding angle brackets or any comments in the header with the URLs. If parsing fails, the value is `null`.
+The header field is parsed as a list of URLs, as described in [RFC2369](https://www.rfc-editor.org/rfc/rfc2369), into the `String[]` type. Values do not include the surrounding angle brackets or any comments in the header with the URLs. If parsing fails, the value is `null`.
 
 To prevent obviously nonsense behaviour, which can lead to interoperability issues, this form may only be fetched or set for the following header fields:
 
-* List-Help
-* List-Unsubscribe
-* List-Subscribe
-* List-Post
-* List-Owner
-* List-Archive
-* Any header field not defined in [@!RFC5322] or [@!RFC2369]
+- List-Help
+- List-Unsubscribe
+- List-Subscribe
+- List-Post
+- List-Owner
+- List-Archive
+- Any header field not defined in [RFC5322](https://www.rfc-editor.org/rfc/rfc5322) or [RFC2369](https://www.rfc-editor.org/rfc/rfc2369)
 
 ### Header Fields Properties
 
 The following low-level **Email** property is specified for complete access to the header data of the message:
 
 - **headers**: `EmailHeader[]` (immutable)
-  This is a list of all header fields [@!RFC5322], in the same order they appear in the message. An **EmailHeader** object has the following properties:
+  This is a list of all header fields [RFC5322](https://www.rfc-editor.org/rfc/rfc5322), in the same order they appear in the message. An **EmailHeader** object has the following properties:
 
-    - **name**: `String`
-      The header *field name* as defined in [@!RFC5322], with the same capitalization that it has in the message.
-    - **value**: `String`
-      The header *field value* as defined in [@!RFC5322], in *Raw* form.
+  - **name**: `String`
+      The header *field name* as defined in [RFC5322](https://www.rfc-editor.org/rfc/rfc5322), with the same capitalization that it has in the message.
+  - **value**: `String`
+      The header *field value* as defined in [RFC5322](https://www.rfc-editor.org/rfc/rfc5322), in *Raw* form.
 
 In addition, the client may request/send properties representing individual header fields of the form:
 
@@ -259,10 +259,10 @@ In addition, the client may request/send properties representing individual head
 
 Where `{header-field-name}` means any series of one or more printable ASCII characters (i.e., characters that have values between 33 and 126, inclusive), except for colon (:). The property may also have the following suffixes:
 
-  - **:as{header-form}**
+- **:as{header-form}**
     This means the value is in a parsed form, where `{header-form}` is one of the parsed-form names specified above. If not given, the value is in *Raw* form.
 
-  - **:all**
+- **:all**
     This means the value is an array, with the items corresponding to each instance of the header field, in the order they appear in the message. If this suffix is not used, the result is the value of the **last** instance of the header field (i.e., identical to the **last** item in the array if :all is used), or `null` if none.
 
 If both suffixes are used, they MUST be specified in the order above. Header field names are matched case insensitively. The value is typed according to the requested form or to an array of that type if :all is used. If no header fields exist in the message with the requested name, the value is `null` if fetching a single instance or an empty array if requesting :all.
@@ -304,20 +304,20 @@ The following convenience properties are also specified for the **Email** object
 
 ### Body Parts
 
-These properties are derived from the message body [@!RFC5322] and its MIME entities [@RFC2045].
+These properties are derived from the message body [RFC5322](https://www.rfc-editor.org/rfc/rfc5322) and its MIME entities [@RFC2045].
 
 An **EmailBodyPart** object has the following properties:
 
 - **partId**: `String|null`
   Identifies this part uniquely within the Email. This is scoped to the *emailId* and has no meaning outside of the JMAP Email object representation. This is `null` if, and only if, the part is of type `multipart/*`.
 - **blobId**: `Id|null`
-  The id representing the raw octets of the contents of the part, after decoding any known *Content-Transfer-Encoding* (as defined in [@!RFC2045]), or `null` if, and only if, the part is of type `multipart/*`. Note that two parts may be transfer-encoded differently but have the same blob id if their decoded octets are identical and the server is using a secure hash of the data for the blob id. If the transfer encoding is unknown, it is treated as though it had no transfer encoding.
+  The id representing the raw octets of the contents of the part, after decoding any known *Content-Transfer-Encoding* (as defined in [RFC2045](https://www.rfc-editor.org/rfc/rfc2045)), or `null` if, and only if, the part is of type `multipart/*`. Note that two parts may be transfer-encoded differently but have the same blob id if their decoded octets are identical and the server is using a secure hash of the data for the blob id. If the transfer encoding is unknown, it is treated as though it had no transfer encoding.
 - **size**: `UnsignedInt`
   The size, in octets, of the raw data after content transfer decoding (as referenced by the *blobId*, i.e., the number of octets in the file the user would download).
 - **headers**: `EmailHeader[]`
   This is a list of all header fields in the part, in the order they appear in the message. The values are in *Raw* form.
 - **name**: `String|null`
-  This is the decoded *filename* parameter of the *Content-Disposition* header field per [@!RFC2231], or (for compatibility with existing systems) if not present, then it's the decoded *name* parameter of the *Content-Type* header field per [@!RFC2047].
+  This is the decoded *filename* parameter of the *Content-Disposition* header field per [RFC2231](https://www.rfc-editor.org/rfc/rfc2231), or (for compatibility with existing systems) if not present, then it's the decoded *name* parameter of the *Content-Type* header field per [RFC2047](https://www.rfc-editor.org/rfc/rfc2047).
 - **type**: `String`
   The value of the *Content-Type* header field of the part, if present; otherwise, the implicit type as per the MIME standard (`text/plain` or `message/rfc822` if inside a `multipart/digest`). CFWS is removed and any parameters are stripped.
 - **charset**: `String|null`
@@ -325,11 +325,11 @@ An **EmailBodyPart** object has the following properties:
 - **disposition**: `String|null`
   The value of the *Content-Disposition* header field of the part, if present; otherwise, it's `null`. CFWS is removed and any parameters are stripped.
 - **cid**: `String|null`
-  The value of the *Content-Id* header field of the part, if present; otherwise it's `null`. CFWS and surrounding angle brackets (`<>`) are removed. This may be used to reference the content from within a `text/html` body part [HTML](https://www.w3.org/TR/html52/) using the `cid:` protocol, as defined in [@!RFC2392].
+  The value of the *Content-Id* header field of the part, if present; otherwise it's `null`. CFWS and surrounding angle brackets (`<>`) are removed. This may be used to reference the content from within a `text/html` body part [HTML](https://www.w3.org/TR/html52/) using the `cid:` protocol, as defined in [RFC2392](https://www.rfc-editor.org/rfc/rfc2392).
 - **language**: `String[]|null`
-  The list of language tags, as defined in [@!RFC3282], in the *Content-Language* header field of the part, if present.
+  The list of language tags, as defined in [RFC3282](https://www.rfc-editor.org/rfc/rfc3282), in the *Content-Language* header field of the part, if present.
 - **location**: `String|null`
-  The URI, as defined in [@!RFC2557], in the *Content-Location* header field of the part, if present.
+  The URI, as defined in [RFC2557](https://www.rfc-editor.org/rfc/rfc2557), in the *Content-Location* header field of the part, if present.
 - **subParts**: `EmailBodyPart[]|null`
   If the type is `multipart/*`, this contains the body parts of each child.
 
@@ -344,15 +344,15 @@ The following **Email** properties are specified for access to the body data of 
 
     An **EmailBodyValue** object has the following properties:
 
-    * **value**: `String`
+  - **value**: `String`
       The value of the body part after decoding *Content-Transfer-Encoding* and
       the *Content-Type* charset, if both known to the server, and with any CRLF replaced with a single LF. The server MAY use heuristics to determine the charset to use for decoding if the charset is unknown, no charset is given, or it believes the charset given is incorrect. Decoding is best effort; the server SHOULD insert the unicode replacement character (U+FFFD) and continue when a malformed section is encountered.
 
         Note that due to the charset decoding and line ending normalisation, the length of this string will probably not be exactly the same as the *size* property on the corresponding EmailBodyPart.
 
-    * **isEncodingProblem**: `Boolean` (default: false)
+  - **isEncodingProblem**: `Boolean` (default: false)
       This is `true` if malformed sections were found while decoding the charset, or the charset was unknown, or the content-transfer-encoding was unknown.
-    * **isTruncated**: `Boolean` (default: false)
+  - **isTruncated**: `Boolean` (default: false)
       This is `true` if the *value* has been truncated.
 
     See the Security Considerations section for issues related to truncation
@@ -365,13 +365,13 @@ The following **Email** properties are specified for access to the body data of 
 - **attachments**: `EmailBodyPart[]` (immutable)
   A list, traversing depth-first, of all parts in *bodyStructure* that satisfy either of the following conditions:
 
-    - not of type `multipart/*` and not included in *textBody* or *htmlBody*
-    - of type `image/*`, `audio/*`, or `video/*` and not in both *textBody* and
+  - not of type `multipart/*` and not included in *textBody* or *htmlBody*
+  - of type `image/*`, `audio/*`, or `video/*` and not in both *textBody* and
      *htmlBody*
 
     None of these parts include subParts, including `message/*` types. Attached messages may be fetched using the Email/parse method and the blobId.
 
-    Note that a `text/html` body part [HTML](https://www.w3.org/TR/html52/) may reference image parts in attachments by using `cid:` links to reference the *Content-Id*, as defined in [@!RFC2392], or by referencing the *Content-Location*.
+    Note that a `text/html` body part [HTML](https://www.w3.org/TR/html52/) may reference image parts in attachments by using `cid:` links to reference the *Content-Id*, as defined in [RFC2392](https://www.rfc-editor.org/rfc/rfc2392), or by referencing the *Content-Location*.
 - **hasAttachment**: `Boolean` (immutable; server-set)
   This is `true` if there are one or more parts in the message that a client UI should offer as downloadable. A server SHOULD set hasAttachment to `true` if the *attachments* list contains at least one item that does not have `Content-Disposition: inline`. The server MAY ignore parts in this list that are processed automatically in some way or are referenced as embedded images in one of the `text/html` parts of the message.
 
@@ -508,10 +508,9 @@ In this case, the above algorithm would decompose this to:
     htmlBody => [ A, E, K ]
     attachments => [ C, F, G, H, J ]
 
-
 ## Email/get
 
-This is a standard "/get" method as described in [@!RFC8620], Section 5.1, with the following additional request arguments:
+This is a standard "/get" method as described in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 5.1, with the following additional request arguments:
 
 - **bodyProperties**: `String[]`
   A list of properties to fetch for each EmailBodyPart returned. If omitted, this defaults to:
@@ -623,14 +622,13 @@ and response:
       "notFound": [ "f123u456" ]
     }, "#1" ]]
 
-
 ## Email/changes
 
-This is a standard "/changes" method as described in [@!RFC8620], Section 5.2. If generating intermediate states for a large set of changes, it is recommended that newer changes be returned first, as these are generally of more interest to users.
+This is a standard "/changes" method as described in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 5.2. If generating intermediate states for a large set of changes, it is recommended that newer changes be returned first, as these are generally of more interest to users.
 
 ## Email/query
 
-This is a standard "/query" method as described in [@!RFC8620], Section 5.5, but with the following additional request arguments:
+This is a standard "/query" method as described in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 5.5, but with the following additional request arguments:
 
 - **collapseThreads**: `Boolean` (default: false)
   If `true`, Emails in the same Thread as a previous Email in the list (given the filter and sort order) will be removed from the list. This means only one Email at most will be included in the list for any given Thread.
@@ -686,7 +684,7 @@ If zero properties are specified on the FilterCondition, the condition MUST alwa
 
 The exact semantics for matching `String` fields is **deliberately not defined** to allow for flexibility in indexing implementation, subject to the following:
 
-- Any syntactically correct encoded sections [@!RFC2047] of header fields with a known encoding SHOULD be decoded before attempting to match text.
+- Any syntactically correct encoded sections [RFC2047](https://www.rfc-editor.org/rfc/rfc2047) of header fields with a known encoding SHOULD be decoded before attempting to match text.
 - When searching inside a `text/html` body part, any text considered markup rather than content SHOULD be ignored, including HTML tags and most attributes, anything inside the `<head>` tag, Cascading Style Sheets (CSS) and JavaScript. Attribute content intended for presentation to the user such as "alt" and "title" SHOULD be considered in the search.
 - Text SHOULD be matched in a case-insensitive manner.
 - Text contained in either (but matched) single (') or double (") quotes SHOULD be treated as a **phrase search**; that is, a match is required for that exact word or sequence of words, excluding the surrounding quotation marks.
@@ -709,7 +707,7 @@ The following values for the *property* field on the Comparator object SHOULD be
 - **size** - The *size* as returned in the Email object.
 - **from** – This is taken to be either the *name* property or if `null`/empty, the *email* property of the **first** EmailAddress object in the Email's *from* property. If still none, consider the value to be the empty string.
 - **to** - This is taken to be either the *name* property or if `null`/empty, the *email* property of the **first** EmailAddress object in the Email's *to* property. If still none, consider the value to be the empty string.
-- **subject** - This is taken to be the base subject of the message, as defined in Section 2.1 of [@!RFC5256].
+- **subject** - This is taken to be the base subject of the message, as defined in Section 2.1 of [RFC5256](https://www.rfc-editor.org/rfc/rfc5256).
 - **sentAt** - The *sentAt* property on the Email object.
 - **hasKeyword** - This value MUST be considered `true` if the Email has the keyword given as an additional *keyword* property on the *Comparator* object, or `false` otherwise.
 - **allInThreadHaveKeyword** - This value MUST be considered `true` for the Email if **all** of the Emails in the same Thread have the keyword given as an additional *keyword* property on the *Comparator* object.
@@ -739,23 +737,23 @@ When *collapseThreads* is `true`, then after filtering and sorting the Email lis
 
 ## Email/queryChanges
 
-This is a standard "/queryChanges" method as described in [@!RFC8620], Section 5.6, with the following additional request argument:
+This is a standard "/queryChanges" method as described in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 5.6, with the following additional request argument:
 
 - **collapseThreads**: `Boolean` (default: false)
   The *collapseThreads* argument that was used with *Email/query*.
 
 ## Email/set
 
-This is a standard "/set" method as described in [@!RFC8620], Section 5.3. The *Email/set* method encompasses:
+This is a standard "/set" method as described in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 5.3. The *Email/set* method encompasses:
 
 - Creating a draft
 - Changing the keywords of an Email (e.g., unread/flagged status)
 - Adding/removing an Email to/from Mailboxes (moving a message)
 - Deleting Emails
 
-The format of the keywords/mailboxIds properties means that when updating an Email, you can either replace the entire set of keywords/Mailboxes (by setting the full value of the property) or add/remove individual ones using the JMAP patch syntax (see [@!RFC8620], Section 5.3 for the specification and Section 5.7 for an example).
+The format of the keywords/mailboxIds properties means that when updating an Email, you can either replace the entire set of keywords/Mailboxes (by setting the full value of the property) or add/remove individual ones using the JMAP patch syntax (see [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 5.3 for the specification and Section 5.7 for an example).
 
-Due to the format of the Email object, when creating an Email there are a number of ways to specify the same information. To ensure that the message [@!RFC5322] to create is unambiguous, the following constraints apply to Email objects submitted for creation:
+Due to the format of the Email object, when creating an Email there are a number of ways to specify the same information. To ensure that the message [RFC5322](https://www.rfc-editor.org/rfc/rfc5322) to create is unambiguous, the following constraints apply to Email objects submitted for creation:
 
 - The *headers* property MUST NOT be given on either the top-level Email or an
   EmailBodyPart — the client must set each header field as an individual
@@ -790,7 +788,7 @@ Due to the format of the Email object, when creating an Email there are a number
 
 Creation attempts that violate any of this SHOULD be rejected with an `invalidProperties` error; however, a server MAY choose to modify the Email (e.g., choose between conflicting headers, use a different content-encoding, etc.) to comply with its requirements instead.
 
-The server MAY also choose to set additional headers. If not included, the server MUST generate and set a `Message-ID` header field in conformance with [@!RFC5322], Section 3.6.4, and a `Date` header field in conformance with Section 3.6.1.
+The server MAY also choose to set additional headers. If not included, the server MUST generate and set a `Message-ID` header field in conformance with [RFC5322](https://www.rfc-editor.org/rfc/rfc5322), Section 3.6.4, and a `Date` header field in conformance with Section 3.6.1.
 
 The final message generated may be invalid per RFC 5322. For example, if it is a half-finished draft, the To header field may have a value that does not conform to the required syntax for this header. The message will be checked for strict conformance when submitted for sending (see the EmailSubmission object description).
 
@@ -815,16 +813,15 @@ For **create** and **update**:
 
 ## Email/copy
 
-This is a standard "/copy" method as described in [@!RFC8620], Section 5.4, except only the *mailboxIds*, *keywords*, and *receivedAt* properties may be set during the copy. This method cannot modify the message represented by the Email.
+This is a standard "/copy" method as described in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 5.4, except only the *mailboxIds*, *keywords*, and *receivedAt* properties may be set during the copy. This method cannot modify the message represented by the Email.
 
-The server MAY forbid two Email objects with identical message content [@!RFC5322], or even just with the same Message-ID [@!RFC5322], to coexist within an account; if the target account already has the Email, the copy will be rejected with a standard `alreadyExists` error.
+The server MAY forbid two Email objects with identical message content [RFC5322](https://www.rfc-editor.org/rfc/rfc5322), or even just with the same Message-ID [RFC5322](https://www.rfc-editor.org/rfc/rfc5322), to coexist within an account; if the target account already has the Email, the copy will be rejected with a standard `alreadyExists` error.
 
 For successfully copied Email objects, the *created* response contains the *id*, *blobId*, *threadId*, and *size* properties of the new object.
 
-
 ## Email/import
 
-The *Email/import* method adds messages [@!RFC5322] to the set of Emails in an account. The server MUST support messages with Email Address Internationalization (EAI) headers [@!RFC6532]. The messages must first be uploaded as blobs using the standard upload mechanism. The method takes the following arguments:
+The *Email/import* method adds messages [RFC5322](https://www.rfc-editor.org/rfc/rfc5322) to the set of Emails in an account. The server MUST support messages with Email Address Internationalization (EAI) headers [RFC6532](https://www.rfc-editor.org/rfc/rfc6532). The messages must first be uploaded as blobs using the standard upload mechanism. The method takes the following arguments:
 
 - **accountId**: `Id`
   The id of the account to use.
@@ -836,7 +833,7 @@ The *Email/import* method adds messages [@!RFC5322] to the set of Emails in an a
 An **EmailImport** object has the following properties:
 
 - **blobId**: `Id`
-  The id of the blob containing the raw message [@!RFC5322].
+  The id of the blob containing the raw message [RFC5322](https://www.rfc-editor.org/rfc/rfc5322).
 - **mailboxIds**: `Id[Boolean]`
   The ids of the Mailboxes to assign this Email to. At least one Mailbox MUST be given.
 - **keywords**: `String[Boolean]` (default: \{\})
@@ -846,13 +843,13 @@ An **EmailImport** object has the following properties:
 
 Each Email to import is considered an atomic unit that may succeed or fail individually. Importing successfully creates a new Email object from the data referenced by the blobId and applies the given Mailboxes, keywords, and receivedAt date.
 
-The server MAY forbid two Email objects with the same exact content [@!RFC5322], or even just with the same Message-ID [@!RFC5322], to coexist within an account. In this case, it MUST reject attempts to import an Email considered to be a duplicate with an `alreadyExists` SetError. An *existingId* property of type `Id` MUST be included on the SetError object with the id of the existing Email. If duplicates are allowed, the newly created Email object MUST have a separate id and independent mutable properties to the existing object.
+The server MAY forbid two Email objects with the same exact content [RFC5322](https://www.rfc-editor.org/rfc/rfc5322), or even just with the same Message-ID [RFC5322](https://www.rfc-editor.org/rfc/rfc5322), to coexist within an account. In this case, it MUST reject attempts to import an Email considered to be a duplicate with an `alreadyExists` SetError. An *existingId* property of type `Id` MUST be included on the SetError object with the id of the existing Email. If duplicates are allowed, the newly created Email object MUST have a separate id and independent mutable properties to the existing object.
 
 If the *blobId*, *mailboxIds*, or *keywords* properties are invalid (e.g., missing, wrong type, id not found), the server MUST reject the import with an `invalidProperties` SetError.
 
 If the Email cannot be imported because it would take the account over quota, the import should be rejected with an `overQuota` SetError.
 
-If the blob referenced is not a valid message [@!RFC5322], the server MAY modify the message to fix errors (such as removing NUL octets or fixing invalid headers). If it does this, the *blobId* on the response MUST represent the new representation and therefore be different to the *blobId* on the EmailImport object. Alternatively, the server MAY reject the import with an `invalidEmail` SetError.
+If the blob referenced is not a valid message [RFC5322](https://www.rfc-editor.org/rfc/rfc5322), the server MAY modify the message to fix errors (such as removing NUL octets or fixing invalid headers). If it does this, the *blobId* on the response MUST represent the new representation and therefore be different to the *blobId* on the EmailImport object. Alternatively, the server MAY reject the import with an `invalidEmail` SetError.
 
 The response has the following arguments:
 
@@ -873,7 +870,7 @@ The following additional errors may be returned instead of the *Email/import* re
 
 ## Email/parse
 
-This method allows you to parse blobs as messages [@!RFC5322] to get Email objects. The server MUST support messages with EAI headers [@!RFC6532]. This can be used to parse and display attached messages without having to import them as top-level Email objects in the mail store in their own right.
+This method allows you to parse blobs as messages [RFC5322](https://www.rfc-editor.org/rfc/rfc5322) to get Email objects. The server MUST support messages with EAI headers [RFC6532](https://www.rfc-editor.org/rfc/rfc6532). This can be used to parse and display attached messages without having to import them as top-level Email objects in the mail store in their own right.
 
 The following metadata properties on the Email objects will be `null` if requested:
 
@@ -922,7 +919,6 @@ The response has the following arguments:
 As specified above, parsed forms of headers may only be used on appropriate header fields. Attempting to fetch a form that is forbidden (e.g., `header:From:asDate`) MUST result in the method call being rejected with an `invalidArguments` error.
 
 Where a specific header field is requested as a property, the capitalization of the property name in the response MUST be identical to that used in the request.
-
 
 ## Examples
 

--- a/spec/mail/messagesubmission.mdown
+++ b/spec/mail/messagesubmission.mdown
@@ -15,49 +15,49 @@ An **EmailSubmission** object represents the submission of an Email for delivery
 
     An **Envelope** object has the following properties:
 
-    - **mailFrom**: `Address`
+  - **mailFrom**: `Address`
       The email address to use as the return address in the SMTP submission, plus any parameters to pass with the MAIL FROM address. The JMAP server MAY allow the address to be the empty string.
 
         When a JMAP server performs an SMTP message submission, it MAY use the
-        same id string for the ENVID parameter [@!RFC3461] and the
+        same id string for the ENVID parameter [RFC3461](https://www.rfc-editor.org/rfc/rfc3461) and the
         EmailSubmission object id. Servers that do this MAY replace a
         client-provided value for ENVID with a server-provided value.
 
-    - **rcptTo**: `Address[]`
+  - **rcptTo**: `Address[]`
       The email addresses to send the message to, and any RCPT TO parameters to pass with the recipient.
 
     An **Address** object has the following properties:
 
-    - **email**: `String`
-      The email address being represented by the object. This is a "Mailbox" as used in the Reverse-path or Forward-path of the MAIL FROM or RCPT TO command in [@!RFC5321].
-    - **parameters**: `Object|null`
-      Any parameters to send with the email address (either mail-parameter or rcpt-parameter as appropriate, as specified in [@!RFC5321]). If supplied, each key in the object is a parameter name, and the value is either the parameter value (type `String`) or `null` if the parameter does not take a value. For both name and value, any xtext or unitext encodings are removed (see [@!RFC3461] and [@!RFC6533]) and JSON string encoding is applied.
+  - **email**: `String`
+      The email address being represented by the object. This is a "Mailbox" as used in the Reverse-path or Forward-path of the MAIL FROM or RCPT TO command in [RFC5321](https://www.rfc-editor.org/rfc/rfc5321).
+  - **parameters**: `Object|null`
+      Any parameters to send with the email address (either mail-parameter or rcpt-parameter as appropriate, as specified in [RFC5321](https://www.rfc-editor.org/rfc/rfc5321)). If supplied, each key in the object is a parameter name, and the value is either the parameter value (type `String`) or `null` if the parameter does not take a value. For both name and value, any xtext or unitext encodings are removed (see [RFC3461](https://www.rfc-editor.org/rfc/rfc3461) and [RFC6533](https://www.rfc-editor.org/rfc/rfc6533)) and JSON string encoding is applied.
 
     If the *envelope* property is `null` or omitted on creation, the server MUST generate this from the referenced Email as follows:
 
-    - **mailFrom**: The email address in the *Sender* header field, if present;
+  - **mailFrom**: The email address in the *Sender* header field, if present;
       otherwise, it's the email address in the *From* header field, if present. In either case, no parameters are added.
 
         If multiple addresses are present in one of these header fields, or there is more than one *Sender*/*From* header field, the server SHOULD reject the EmailSubmission as invalid; otherwise, it MUST take the first address in the last *Sender*/*From* header field.
 
         If the address found from this is not allowed by the Identity associated with this submission, the *email* property from the Identity MUST be used instead.
 
-    - **rcptTo**: The deduplicated set of email addresses from the *To*, *Cc*,
+  - **rcptTo**: The deduplicated set of email addresses from the *To*, *Cc*,
       and *Bcc* header fields, if present, with no parameters for any of them.
 
 - **sendAt**: `UTCDate` (immutable; server-set)
   The date the submission was/will be released for delivery.
 
-    If the client successfully used FUTURERELEASE [@!RFC4865] with the submission, this MUST be the time when the server will release the message; otherwise, it MUST be the time the EmailSubmission was created.
+    If the client successfully used FUTURERELEASE [RFC4865](https://www.rfc-editor.org/rfc/rfc4865) with the submission, this MUST be the time when the server will release the message; otherwise, it MUST be the time the EmailSubmission was created.
 
 - **undoStatus**: `String`
   This represents whether the submission may be canceled. This is server set on create and MUST be one of the following values:
 
-    - `pending`: It may be possible to cancel this submission.
-    - `final`: The message has been relayed to at least one recipient in a
+  - `pending`: It may be possible to cancel this submission.
+  - `final`: The message has been relayed to at least one recipient in a
       manner that cannot be recalled. It is no longer possible to cancel this
       submission.
-    - `canceled`: The submission was canceled and will not be delivered
+  - `canceled`: The submission was canceled and will not be delivered
       to any recipient.
 
     On systems that do not support unsending, the value of this property will always be `final`. On systems that do support canceling submission, it will start as `pending` and MAY transition to `final` when the server knows it definitely cannot recall the message, but it MAY just remain `pending`. If in pending state, a client can attempt to cancel the submission by setting this property to `canceled`; if the update succeeds, the submission was successfully canceled, and the message has not been delivered to any of the original recipients.
@@ -69,16 +69,16 @@ An **EmailSubmission** object represents the submission of an Email for delivery
 
     A **DeliveryStatus** object has the following properties:
 
-    - **smtpReply**: `String`
-      The SMTP reply string returned for this recipient when the server last tried to relay the message, or in a later Delivery Status Notification (DSN, as defined in [@!RFC3464]) response for the message. This SHOULD be the response to the RCPT TO stage, unless this was accepted and the message as a whole was rejected at the end of the DATA stage, in which case the DATA stage reply SHOULD be used instead.
+  - **smtpReply**: `String`
+      The SMTP reply string returned for this recipient when the server last tried to relay the message, or in a later Delivery Status Notification (DSN, as defined in [RFC3464](https://www.rfc-editor.org/rfc/rfc3464)) response for the message. This SHOULD be the response to the RCPT TO stage, unless this was accepted and the message as a whole was rejected at the end of the DATA stage, in which case the DATA stage reply SHOULD be used instead.
 
         Multi-line SMTP responses should be concatenated to a single string as follows:
 
-        - The hyphen following the SMTP code on all but the last line is
+    - The hyphen following the SMTP code on all but the last line is
           replaced with a space.
-        - Any prefix in common with the first line is stripped from lines after
+    - Any prefix in common with the first line is stripped from lines after
           the first.
-        - CRLF is replaced by a space.
+    - CRLF is replaced by a space.
 
         For example:
 
@@ -91,47 +91,47 @@ An **EmailSubmission** object represents the submission of an Email for delivery
 
         For messages relayed via an alternative to SMTP, the server MAY generate a synthetic string representing the status instead. If it does this, the string MUST be of the following form:
 
-        - A 3-digit SMTP reply code, as defined in [@!RFC5321], Section 4.2.3.
-        - Then a single space character.
-        - Then an SMTP Enhanced Mail System Status Code as defined in
-          [@!RFC3463], with a registry defined in [@!RFC5248].
-        - Then a single space character.
-        - Then an implementation-specific information string with a
+    - A 3-digit SMTP reply code, as defined in [RFC5321](https://www.rfc-editor.org/rfc/rfc5321), Section 4.2.3.
+    - Then a single space character.
+    - Then an SMTP Enhanced Mail System Status Code as defined in
+          [RFC3463](https://www.rfc-editor.org/rfc/rfc3463), with a registry defined in [RFC5248](https://www.rfc-editor.org/rfc/rfc5248).
+    - Then a single space character.
+    - Then an implementation-specific information string with a
           human-readable explanation of the response.
 
-    - **delivered**: `String`
+  - **delivered**: `String`
       Represents whether the message has been successfully delivered to the recipient. This MUST be one of the following values:
 
-        - `queued`: The message is in a local mail queue and status will change
+    - `queued`: The message is in a local mail queue and status will change
           once it exits the local mail queues. The *smtpReply* property may still change.
-        - `yes`: The message was successfully delivered to the mail store of the
+    - `yes`: The message was successfully delivered to the mail store of the
           recipient. The *smtpReply* property is final.
-        - `no`: Delivery to the recipient permanently failed. The *smtpReply*
+    - `no`: Delivery to the recipient permanently failed. The *smtpReply*
           property is final.
-        - `unknown`: The final delivery status is unknown, (e.g., it was relayed
+    - `unknown`: The final delivery status is unknown, (e.g., it was relayed
           to an external machine and no further information is available). The *smtpReply* property may still change if a DSN arrives.
 
         Note that successful relaying to an external SMTP server SHOULD NOT be taken as an indication that the message has successfully reached the final mail store. In this case though, the server may receive a DSN response, if requested.
 
-        If a DSN is received for the recipient with Action equal to "delivered", as per [@!RFC3464], Section 2.3.3, then the *delivered* property SHOULD be set to `yes`; if the Action equals "failed", the property SHOULD be set to `no`. Receipt of any other DSN SHOULD NOT affect this property.
+        If a DSN is received for the recipient with Action equal to "delivered", as per [RFC3464](https://www.rfc-editor.org/rfc/rfc3464), Section 2.3.3, then the *delivered* property SHOULD be set to `yes`; if the Action equals "failed", the property SHOULD be set to `no`. Receipt of any other DSN SHOULD NOT affect this property.
 
         The server MAY also set this property based on other feedback channels.
 
-    - **displayed**: `String`
+  - **displayed**: `String`
       Represents whether the message has been displayed to the recipient. This MUST be one of the following values:
 
-        - `unknown`: The display status is unknown. This is the initial value.
-        - `yes`: The recipient's system claims the message content has been
+    - `unknown`: The display status is unknown. This is the initial value.
+    - `yes`: The recipient's system claims the message content has been
           displayed to the recipient. Note that there is no guarantee that the recipient has noticed, read, or understood the content.
 
-        If a Message Disposition Notification (MDN) is received for this recipient with Disposition-Type (as per [@!RFC8098], Section 3.2.6.2) equal to "displayed", this property SHOULD be set to `yes`.
+        If a Message Disposition Notification (MDN) is received for this recipient with Disposition-Type (as per [RFC8098](https://www.rfc-editor.org/rfc/rfc8098), Section 3.2.6.2) equal to "displayed", this property SHOULD be set to `yes`.
 
         The server MAY also set this property based on other feedback channels.
 
 - **dsnBlobIds**: `Id[]` (server-set)
-  A list of blob ids for DSNs [@!RFC3464] received for this submission, in order of receipt, oldest first. The blob is the whole MIME message (with a top-level content-type of `multipart/report`), as received.
+  A list of blob ids for DSNs [RFC3464](https://www.rfc-editor.org/rfc/rfc3464) received for this submission, in order of receipt, oldest first. The blob is the whole MIME message (with a top-level content-type of `multipart/report`), as received.
 - **mdnBlobIds**: `Id[]` (server-set)
-  A list of blob ids for MDNs [@!RFC8098] received for this submission, in order of receipt, oldest first. The blob is the whole MIME message (with a top-level content-type of `multipart/report`), as received.
+  A list of blob ids for MDNs [RFC8098](https://www.rfc-editor.org/rfc/rfc8098) received for this submission, in order of receipt, oldest first. The blob is the whole MIME message (with a top-level content-type of `multipart/report`), as received.
 
 JMAP servers MAY choose not to expose DSN and MDN responses as Email objects if they correlate to an EmailSubmission object. It SHOULD only do this if it exposes them in the *dsnBlobIds* and *mdnblobIds* fields instead, and it expects the user to be using clients capable of fetching and displaying delivery status via the EmailSubmission object.
 
@@ -141,15 +141,15 @@ The following JMAP methods are supported.
 
 ## EmailSubmission/get
 
-This is a standard "/get" method as described in [@!RFC8620], Section 5.1.
+This is a standard "/get" method as described in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 5.1.
 
 ## EmailSubmission/changes
 
-This is a standard "/changes" method as described in [@!RFC8620], Section 5.2.
+This is a standard "/changes" method as described in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 5.2.
 
 ## EmailSubmission/query
 
-This is a standard "/query" method as described in [@!RFC8620], Section 5.5.
+This is a standard "/query" method as described in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 5.5.
 
 A **FilterCondition** object has the following properties, any of which may be omitted:
 
@@ -179,11 +179,11 @@ The following EmailSubmission properties MUST be supported for sorting:
 
 ## EmailSubmission/queryChanges
 
-This is a standard "/queryChanges" method as described in [@!RFC8620], Section 5.6.
+This is a standard "/queryChanges" method as described in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 5.6.
 
 ## EmailSubmission/set
 
-This is a standard "/set" method as described in [@!RFC8620], Section 5.3 with the following two additional request arguments:
+This is a standard "/set" method as described in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 5.3 with the following two additional request arguments:
 
 - **onSuccessUpdateEmail**: `Id[PatchObject]|null`
   A map of *EmailSubmission id* to an object containing properties to update on the Email object referenced by the EmailSubmission if the create/update/destroy succeeds. (For references to EmailSubmissions created in the same "/set" invocation, this is equivalent to a creation-reference, so the id will be the creation id prefixed with a `#`.)
@@ -215,9 +215,9 @@ For **create**:
 - `invalidRecipients` – The *rcptTo* property of the envelope (supplied or
   generated) contains at least one rcptTo value which is not a valid email address for sending to. An *invalidRecipients* `String[]` property MUST also be present on the SetError, which is a list of the invalid addresses.
 - `forbiddenMailFrom` – The server does not permit the user to send a message
-  with this envelope From address [@!RFC5321].
+  with this envelope From address [RFC5321](https://www.rfc-editor.org/rfc/rfc5321).
 - `forbiddenFrom` – The server does not permit the user to send a message
-  with the From header field [@!RFC5322] of the message to be sent.
+  with the From header field [RFC5322](https://www.rfc-editor.org/rfc/rfc5322) of the message to be sent.
 - `forbiddenToSend` – The user does not have permission to send at all right
   now for some reason. A *description* `String` property MAY be present on the SetError object to display to the user why they are not permitted.
 
@@ -225,7 +225,6 @@ For **update**:
 
 - `cannotUnsend` – The client attempted to update the *undoStatus* of a valid
   EmailSubmission object from `pending` to `canceled`, but the message cannot be unsent.
-
 
 ### Example
 
@@ -285,7 +284,7 @@ Suppose instead an admin has removed sending rights for the user, so the submiss
 
     Accept-Language: de;q=0.9,en;q=0.8
 
-The server should attempt to choose the best localisation from those it has available based on the Accept-Language header, as described in [@!RFC8620], Section 3.8. If the server has English, French, and German translations, it would choose German as the preferred language and return a response like this:
+The server should attempt to choose the best localisation from those it has available based on the Accept-Language header, as described in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 3.8. If the server has English, French, and German translations, it would choose German as the preferred language and return a response like this:
 
     [[ "EmailSubmission/set", {
       "accountId": "ue411d190",

--- a/spec/mail/securityconsiderations.mdown
+++ b/spec/mail/securityconsiderations.mdown
@@ -1,6 +1,6 @@
 # Security Considerations
 
-All security considerations of JMAP ([@!RFC8620]) apply to this specification. Additional considerations specific to the data types and functionality introduced by this document are described in the following subsections.
+All security considerations of JMAP ([RFC8620](https://www.rfc-editor.org/rfc/rfc8620)) apply to this specification. Additional considerations specific to the data types and functionality introduced by this document are described in the following subsections.
 
 ## EmailBodyPart Value
 
@@ -66,12 +66,11 @@ Messages may consist of multiple parts to be displayed sequentially as a body. C
 
 ## Email Submission
 
-SMTP submission servers [@!RFC6409] use a number of mechanisms to mitigate damage caused by compromised user accounts and end-user systems including rate limiting, anti-virus/anti-spam milters (mail filters), and other technologies. The technologies work better when they have more information about the client connection. If JMAP email submission is implemented as a proxy to an SMTP submission server, it is useful to communicate this information from the JMAP proxy to the submission server. The de facto [XCLIENT](http://www.postfix.org/XCLIENT_README.html) extension to SMTP can be used to do this, but use of an authenticated channel is recommended to limit use of that extension to explicitly authorised proxies.
+SMTP submission servers [RFC6409](https://www.rfc-editor.org/rfc/rfc6409) use a number of mechanisms to mitigate damage caused by compromised user accounts and end-user systems including rate limiting, anti-virus/anti-spam milters (mail filters), and other technologies. The technologies work better when they have more information about the client connection. If JMAP email submission is implemented as a proxy to an SMTP submission server, it is useful to communicate this information from the JMAP proxy to the submission server. The de facto [XCLIENT](http://www.postfix.org/XCLIENT_README.html) extension to SMTP can be used to do this, but use of an authenticated channel is recommended to limit use of that extension to explicitly authorised proxies.
 
-JMAP servers that proxy to an SMTP submission server SHOULD allow use of the *submissions* port [@!RFC8314]. Implementation of a mechanism similar to SMTP XCLIENT is strongly encouraged. While Simple Authentication and Security Layer (SASL) PLAIN over TLS [@!RFC4616] is presently the mandatory-to-implement mechanism for interoperability with SMTP submission servers [@!RFC4954], a JMAP submission proxy SHOULD implement and prefer a stronger mechanism for this use case such as TLS client certificate authentication with SASL EXTERNAL ([@!RFC4422], Appendix A) or Salted Challenge Response Authentication Mechanism (SCRAM) [@!RFC7677].
+JMAP servers that proxy to an SMTP submission server SHOULD allow use of the *submissions* port [RFC8314](https://www.rfc-editor.org/rfc/rfc8314). Implementation of a mechanism similar to SMTP XCLIENT is strongly encouraged. While Simple Authentication and Security Layer (SASL) PLAIN over TLS [RFC4616](https://www.rfc-editor.org/rfc/rfc4616) is presently the mandatory-to-implement mechanism for interoperability with SMTP submission servers [RFC4954](https://www.rfc-editor.org/rfc/rfc4954), a JMAP submission proxy SHOULD implement and prefer a stronger mechanism for this use case such as TLS client certificate authentication with SASL EXTERNAL ([RFC4422](https://www.rfc-editor.org/rfc/rfc4422), Appendix A) or Salted Challenge Response Authentication Mechanism (SCRAM) [RFC7677](https://www.rfc-editor.org/rfc/rfc7677).
 
 In the event the JMAP server directly relays mail to SMTP servers in other administrative domains, implementation of the de facto [milter](http://www.postfix.org/MILTER_README.html) protocol is strongly encouraged to integrate with third-party products that address security issues including anti-virus/anti-spam, reputation protection, compliance archiving, and data loss prevention. Proxying to a local SMTP submission server may be a simpler way to provide such security services.
-
 
 ## Partial Account Access
 
@@ -83,7 +82,7 @@ If the server forbids a single account from having two identical messages, or tw
 
 ## Permission to Send from an Address
 
-In recent years, the email ecosystem has moved towards associating trust with the From address in the message [@!RFC5322], particularly with schemes such as Domain-based Message Authentication, Reporting, and Conformance (DMARC) ([@?RFC7489]).
+In recent years, the email ecosystem has moved towards associating trust with the From address in the message [RFC5322](https://www.rfc-editor.org/rfc/rfc5322), particularly with schemes such as Domain-based Message Authentication, Reporting, and Conformance (DMARC) ([@?RFC7489]).
 
 The set of Identity objects (see Section 6) in an account lets the client know which email addresses the user has permission to send from. Each email submission is associated with an Identity, and servers SHOULD reject submissions where the `From` header field of the message does not correspond to the associated Identity.
 
@@ -91,6 +90,6 @@ The server MAY allow an exception to send an exact copy of an existing message r
 
 If the user attempts to create a new Identity object, the server MUST reject it with the appropriate error if the user does not have permission to use that email address to send from.
 
-The SMTP MAIL FROM address [@!RFC5321] is often confused with the From message header field [@!RFC5322]. The user generally only ever sees the address in the message header field, and this is the primary one to enforce. However, the server MUST also enforce appropriate restrictions on the MAIL FROM address [@!RFC5321] to stop the user from flooding a third-party address with bounces and non-delivery notices.
+The SMTP MAIL FROM address [RFC5321](https://www.rfc-editor.org/rfc/rfc5321) is often confused with the From message header field [RFC5322](https://www.rfc-editor.org/rfc/rfc5322). The user generally only ever sees the address in the message header field, and this is the primary one to enforce. However, the server MUST also enforce appropriate restrictions on the MAIL FROM address [RFC5321](https://www.rfc-editor.org/rfc/rfc5321) to stop the user from flooding a third-party address with bounces and non-delivery notices.
 
 The JMAP submission model provides separate errors for impermissible addresses in either context.

--- a/spec/mail/thread.mdown
+++ b/spec/mail/thread.mdown
@@ -4,7 +4,7 @@ Replies are grouped together with the original message to form a Thread. In JMAP
 
 The exact algorithm for determining whether two Emails belong to the same Thread is not mandated in this spec to allow for compatibility with different existing systems. For new implementations, it is suggested that two messages belong in the same Thread if both of the following conditions apply:
 
-  1. An identical message id [@!RFC5322] appears in both messages in any of the
+  1. An identical message id [RFC5322](https://www.rfc-editor.org/rfc/rfc5322) appears in both messages in any of the
      Message-Id, In-Reply-To, and References header fields.
   2. After stripping automatically added prefixes such as "Fwd:", "Re:",
      "[List-Tag]", etc., and ignoring white space, the subjects are the same. This avoids the situation where a person replies to an old message as a convenient way of finding the right recipient to send to but changes the subject and starts a new conversation.
@@ -22,7 +22,7 @@ The following JMAP methods are supported.
 
 ## Thread/get
 
-This is a standard "/get" method as described in [@!RFC8620], Section 5.1.
+This is a standard "/get" method as described in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 5.1.
 
 ### Example
 
@@ -53,4 +53,4 @@ with response:
 
 ## Thread/changes
 
-This is a standard "/changes" method as described in [@!RFC8620], Section 5.2.
+This is a standard "/changes" method as described in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 5.2.

--- a/spec/mail/vacationresponse.mdown
+++ b/spec/mail/vacationresponse.mdown
@@ -2,7 +2,7 @@
 
 A vacation response sends an automatic reply when a message is delivered to the mail store, informing the original sender that their message may not be read for some time.
 
-Automated message sending can produce undesirable behaviour. To avoid this, implementors MUST follow the recommendations set forth in [@!RFC3834].
+Automated message sending can produce undesirable behaviour. To avoid this, implementors MUST follow the recommendations set forth in [RFC3834](https://www.rfc-editor.org/rfc/rfc3834).
 
 The **VacationResponse** object represents the state of vacation-response-related settings for an account. It has the following properties:
 
@@ -25,10 +25,10 @@ The following JMAP methods are supported.
 
 ## VacationResponse/get
 
-This is a standard "/get" method as described in [@!RFC8620], Section 5.1.
+This is a standard "/get" method as described in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 5.1.
 
 There MUST only be exactly one VacationResponse object in an account. It MUST have the id "singleton".
 
 ## VacationResponse/set
 
-This is a standard "/set" method as described in [@!RFC8620], Section 5.3.
+This is a standard "/set" method as described in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 5.3.

--- a/spec/mdn/mdn.mdown
+++ b/spec/mdn/mdn.mdown
@@ -1,22 +1,22 @@
 # Introduction
 
-JMAP ([@!RFC8620] – JSON Meta Application Protocol) is a generic protocol for synchronising data, such as mail, calendars or contacts, between a client and a server. It is optimised for mobile and web environments, and provides a consistent interface to different data types.
+JMAP ([RFC8620](https://www.rfc-editor.org/rfc/rfc8620) – JSON Meta Application Protocol) is a generic protocol for synchronising data, such as mail, calendars or contacts, between a client and a server. It is optimised for mobile and web environments, and provides a consistent interface to different data types.
 
-JMAP for Mail ([@!RFC8621] - The JSON Meta Application Protocol (JMAP) for Mail) specifies a data model for synchronising email data with a server using JMAP. Clients can use this to efficiently search, access, organise, and send messages.
+JMAP for Mail ([RFC8621](https://www.rfc-editor.org/rfc/rfc8621) - The JSON Meta Application Protocol (JMAP) for Mail) specifies a data model for synchronising email data with a server using JMAP. Clients can use this to efficiently search, access, organise, and send messages.
 
-Message Disposition Notifications (MDNs) are defined in [@!RFC8098] and are used as "read receipts", "acknowledgements", or "receipt notifications".
+Message Disposition Notifications (MDNs) are defined in [RFC8098](https://www.rfc-editor.org/rfc/rfc8098) and are used as "read receipts", "acknowledgements", or "receipt notifications".
 
 A client can come across MDNs in different ways:
 
 1. When receiving an email message, an MDN can be sent to the sender. This specification defines an MDN/send method to cover this case.
-2. When sending an email message, an MDN can be requested. This must be done with the help of a header field, and is already specified by [@!RFC8098] and can already be handled by [@!RFC8621] this way.
-3. When receiving an MDN, the MDN could be related to an existing sent message. This is already covered by [@!RFC8621] in the EmailSubmission object. A client might want to display detailed information about a received MDN. This specification defines an MDN/parse method to cover this case.
+2. When sending an email message, an MDN can be requested. This must be done with the help of a header field, and is already specified by [RFC8098](https://www.rfc-editor.org/rfc/rfc8098) and can already be handled by [RFC8621](https://www.rfc-editor.org/rfc/rfc8621) this way.
+3. When receiving an MDN, the MDN could be related to an existing sent message. This is already covered by [RFC8621](https://www.rfc-editor.org/rfc/rfc8621) in the EmailSubmission object. A client might want to display detailed information about a received MDN. This specification defines an MDN/parse method to cover this case.
 
 ## Notational conventions
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in BCP 14 [@!RFC2119] [@!RFC8174] when, and only when, they appear in all capitals, as shown here.
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in BCP 14 [RFC2119](https://www.rfc-editor.org/rfc/rfc2119) [RFC8174](https://www.rfc-editor.org/rfc/rfc8174) when, and only when, they appear in all capitals, as shown here.
 
-Type signatures, examples and property descriptions in this document follow the conventions established in section 1.1 of [@!RFC8620]. Data types defined in the core specification are also used in this document.
+Type signatures, examples and property descriptions in this document follow the conventions established in section 1.1 of [RFC8620](https://www.rfc-editor.org/rfc/rfc8620). Data types defined in the core specification are also used in this document.
 
 Servers MUST support all properties specified for the new data types defined in this document.
 
@@ -28,7 +28,7 @@ Because keywords are case-insensitive in IMAP but case-sensitive in JMAP, the "$
 
 ## Addition to the capabilities object
 
-Capabilities are announced as part of the standard JMAP Session resource; see [@!RFC8620], section 2. This defines a new capability, "urn:ietf:params:jmap:mdn".
+Capabilities are announced as part of the standard JMAP Session resource; see [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), section 2. This defines a new capability, "urn:ietf:params:jmap:mdn".
 
 The capability "urn:ietf:params:jmap:mdn" being present in the "accountCapabilities" property of an account represents support for the "MDN" data type, parsing MDNs via the "MDN/parse" method, and creating and sending MDN messages via the "MDN/send" method.
 Servers that include the capability in one or more "accountCapabilities" properties MUST also include the property in the "capabilities" property.
@@ -45,7 +45,7 @@ An **MDN** object has the following properties:
   Subject used as `Subject` header field for this MDN.
 - textBody: `String|null`
   Human readable part of the MDN, as plain text.
-- includeOriginalMessage: `Boolean` (default: false). If `true`, the content of the original message will appear in the third component of the multipart/report generated for the MDN. See [@!RFC8098] for details and security considerations.
+- includeOriginalMessage: `Boolean` (default: false). If `true`, the content of the original message will appear in the third component of the multipart/report generated for the MDN. See [RFC8098](https://www.rfc-editor.org/rfc/rfc8098) for details and security considerations.
 - reportingUA: `String|null`
   Name of the MUA creating this MDN. It is used to build the MDN Report part of the MDN. Note that a `null` value may have better privacy properties.
 - disposition: `Disposition`
@@ -57,11 +57,11 @@ An **MDN** object has the following properties:
 - finalRecipient: `String|null`
   Recipient for which the MDN is being issued.  If set, it overrides the value that would be calculated by the server from the Identity defined in the "MDN/Send" method, unless explicitly set by the client.
 - originalMessageId: `String|null` (server-set)
-  Message-ID (the [@!RFC5322] header field, not the JMAP id) of the message for which the MDN is being issued.
+  Message-ID (the [RFC5322](https://www.rfc-editor.org/rfc/rfc5322) header field, not the JMAP id) of the message for which the MDN is being issued.
 - error: `String[]|null` (server-set)
   Additional information in the form of text messages when the "error" disposition modifier appears.
 - extensionFields: `String[String]|null`
-  Object where keys are extension-field names and values are extension-field values (see [@!RFC8098] Section 3.3).
+  Object where keys are extension-field names and values are extension-field values (see [RFC8098](https://www.rfc-editor.org/rfc/rfc8098) Section 3.3).
 
   A **Disposition** object has the following properties:
 
@@ -72,11 +72,11 @@ An **MDN** object has the following properties:
   - type: `String`
     This MUST be one of the following strings: "deleted" / "dispatched" / "displayed" / "processed"
 
-  See [@!RFC8098] for the exact meaning of these different fields. These fields are defined case insensitive in [@!RFC8098] but are case sensitive in this RFC and MUST be converted to lowercase by "MDN/parse".
+  See [RFC8098](https://www.rfc-editor.org/rfc/rfc8098) for the exact meaning of these different fields. These fields are defined case insensitive in [RFC8098](https://www.rfc-editor.org/rfc/rfc8098) but are case sensitive in this RFC and MUST be converted to lowercase by "MDN/parse".
 
 ## MDN/send
 
-The MDN/send method sends an [@!RFC5322] message from an MDN object. When calling this method the "using" property of the Request object MUST contain the capabilities "urn:ietf:params:jmap:mdn" and "urn:ietf:params:jmap:mail"; the latter because of the implicit call to Email/set and the use of Identities, described below.
+The MDN/send method sends an [RFC5322](https://www.rfc-editor.org/rfc/rfc5322) message from an MDN object. When calling this method the "using" property of the Request object MUST contain the capabilities "urn:ietf:params:jmap:mdn" and "urn:ietf:params:jmap:mail"; the latter because of the implicit call to Email/set and the use of Identities, described below.
 The method takes the following arguments:
 
 - accountId: `Id`
@@ -97,7 +97,7 @@ The response has the following arguments:
 - notSent: `Id[SetError]|null`
   A map of the creation id to a SetError object for each record that failed to be sent, or null if all successful.
 
-In this context, the existing SetError types defined in [@!RFC8620] and [@!RFC8621] are interpreted as follows:
+In this context, the existing SetError types defined in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620) and [RFC8621](https://www.rfc-editor.org/rfc/rfc8621) are interpreted as follows:
 
 - notFound: The reference Email id cannot be found, or has no valid "Disposition-Notification-To" header field.
 - forbidden: MDN/send would violate an ACL or other permissions policy.
@@ -121,7 +121,7 @@ The client is expected to explicitly update each "Email" for which an "MDN/send"
 
 ## MDN/parse
 
-This method allows a client to parse blobs as [@!RFC5322] messages to get MDN objects. This can be used to parse and get detailed information about blobs referenced in the "mdnBlobIds" of the EmailSubmission object, or any email message the client could expect to be an MDN.
+This method allows a client to parse blobs as [RFC5322](https://www.rfc-editor.org/rfc/rfc5322) messages to get MDN objects. This can be used to parse and get detailed information about blobs referenced in the "mdnBlobIds" of the EmailSubmission object, or any email message the client could expect to be an MDN.
 
 The "forEmailId" property can be null or missing if the "originalMessageId" property is missing or does not refer to an existing message, or if the server cannot efficiently calculate the related message (for example, if several messages get the same "Message-Id" header field).
 
@@ -148,7 +148,6 @@ The following additional errors may be returned instead of the MDN/parse respons
 - requestTooLarge: The number of ids requested by the client exceeds the maximum number the server is willing to process in a single method call.
 - invalidArguments: If the accountId given cannot be found, the MDN parsing is rejected with an `invalidArguments` error.
 
-
 # Samples
 
 ## Sending an MDN for a received email message
@@ -162,8 +161,8 @@ A client can use the following request to send an MDN back to the sender:
         "k1546": {
           "forEmailId": "Md45b47b4877521042cec0938",
           "subject": "Read receipt for: World domination",
-          "textBody": "This receipt shows that the email has been 
-              displayed on your recipient's computer. There is no 
+          "textBody": "This receipt shows that the email has been
+              displayed on your recipient's computer. There is no
               guaranty it has been read or understood.",
           "reportingUA": "joes-pc.cs.example.com; Foomail 97.1",
           "disposition": {
@@ -217,7 +216,7 @@ If the `$mdnsent` keyword has already been set, the server can answer an error:
 
 ## Asking for MDN when sending an email message
 
-This is done with the [@!RFC8621] "Email/set" "create" method.
+This is done with the [RFC8621](https://www.rfc-editor.org/rfc/rfc8621) "Email/set" "create" method.
 
     [[ "Email/set", {
       "accountId": "ue150411c",
@@ -264,8 +263,8 @@ The server responds:
         "0f9f65ab-dc7b-4146-850f-6e4881093965": {
           "forEmailId": "Md45b47b4877521042cec0938",
           "subject": "Read receipt for: World domination",
-          "textBody": "This receipt shows that the email has been 
-              displayed on your recipient's computer. There is no 
+          "textBody": "This receipt shows that the email has been
+              displayed on your recipient's computer. There is no
               guaranty it has been read or understood.",
           "reportingUA": "joes-pc.cs.example.com; Foomail 97.1",
           "disposition": {
@@ -311,7 +310,7 @@ Security and privacy considerations: this document, section 5.
 
 ## JMAP Error Codes Registry
 
-This section registers one new error code in the "JMAP Error Codes" registry, as defined in [@!RFC8620].
+This section registers one new error code in the "JMAP Error Codes" registry, as defined in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620).
 
 JMAP Error Code: mdnAlreadySent
 
@@ -325,6 +324,6 @@ Description: The message has the `$mdnsent` keyword already set. The client MUST
 
 # Security considerations
 
-The same considerations regarding MDN (see [@!RFC8098] and [@!RFC3503]) apply to this document.
+The same considerations regarding MDN (see [RFC8098](https://www.rfc-editor.org/rfc/rfc8098) and [RFC3503](https://www.rfc-editor.org/rfc/rfc3503)) apply to this document.
 
 In order to reinforce trust regarding the relation between the user sending an email message and the identity of this user, the server SHOULD validate in conformance to the provided Identity that the user is permitted to use the finalRecipient value and return a forbiddenFrom error if not.

--- a/spec/quotas/acknowledgements.mdown
+++ b/spec/quotas/acknowledgements.mdown
@@ -4,10 +4,10 @@ Thank you to Michael Bailly, that co-wrote the first draft version of this docum
 
 Thank you to Benoit Tellier for his constant help and support on writing this document.
 
-Thank you to Raphael Ouazana for sharing his own experience on how to write a RFC after finalizing his own document, the [@!RFC9007].
+Thank you to Raphael Ouazana for sharing his own experience on how to write a RFC after finalizing his own document, the [RFC9007](https://www.rfc-editor.org/rfc/rfc9007).
 
 Thank you to Bron Gondwana, Neil Jenkins, Alexei Melnikov, Joris Baum and the people from the IETF JMAP working group in general
-that helped with extensive discussions, reviews and feedbacks. 
+that helped with extensive discussions, reviews and feedbacks.
 
-Thank you to the people in the IETF organization that took the time to read, understand, comment and give great feedbacks 
+Thank you to the people in the IETF organization that took the time to read, understand, comment and give great feedbacks
 in the last rounds.

--- a/spec/quotas/intro.mdown
+++ b/spec/quotas/intro.mdown
@@ -1,6 +1,6 @@
 # Introduction
 
-JMAP ([@!RFC8620] – JSON Meta Application Protocol) is a generic protocol for synchronising data, such as mails,
+JMAP ([RFC8620](https://www.rfc-editor.org/rfc/rfc8620) – JSON Meta Application Protocol) is a generic protocol for synchronising data, such as mails,
 calendars or contacts, between a client and a server. It is optimised for mobile and web environments, and aims
 to provide a consistent interface to different data types.
 
@@ -13,22 +13,22 @@ This specification does not address quota administration, which should be handle
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
 "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and
 "OPTIONAL" in this document are to be interpreted as described in BCP
-14 [@!RFC2119] [@!RFC8174] when, and only when, they appear in all
+14 [RFC2119](https://www.rfc-editor.org/rfc/rfc2119) [RFC8174](https://www.rfc-editor.org/rfc/rfc8174) when, and only when, they appear in all
 capitals, as shown here.
 
 Type signatures, examples and property descriptions in this document follow the conventions established in section 1.1
-of [@!RFC8620]. Data types defined in the core specification are also used in this document.
+of [RFC8620](https://www.rfc-editor.org/rfc/rfc8620). Data types defined in the core specification are also used in this document.
 
 ## Terminology
 
-This document reuses the terminology from the core JMAP specification established in section 1.6 of [@!RFC8620].
+This document reuses the terminology from the core JMAP specification established in section 1.6 of [RFC8620](https://www.rfc-editor.org/rfc/rfc8620).
 
-The term Quota (when capitalized) is used to refer to the data type defined in this document 
+The term Quota (when capitalized) is used to refer to the data type defined in this document
 in (#quota) and instance of that data type.
 
 # Addition to the capabilities object
 
-The capabilities object is returned as part of the JMAP Session object; see [@!RFC8620], section 2.
+The capabilities object is returned as part of the JMAP Session object; see [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), section 2.
 
 This document defines one additional capability URI.
 

--- a/spec/quotas/quota.mdown
+++ b/spec/quotas/quota.mdown
@@ -7,34 +7,34 @@ The quota is an object that displays the limit set to an account usage. It then 
 The quota object MUST contain the following fields:
 
 * id: "Id"
-  
+
   The unique identifier for this object.
 
 * resourceType: "String"
-  
+
   The resource type of the quota as defined in (#resourcetype).
 
 * used: "UnsignedInt"
-  
+
   The current usage of the defined quota, using the "resourceType" defined as unit of measure.
 Computation of this value is handled by the server.
 
 * hardLimit: "UnsignedInt"
-  
-  The hard limit set by this quota, using the "resourceType" defined as unit of measure. Objects 
+
+  The hard limit set by this quota, using the "resourceType" defined as unit of measure. Objects
 in scope may not be created or updated if this limit is reached.
 
 * scope: "String"
-  
+
   The "Scope" of this quota as defined in (#scope).
 
-* name: "String" 
-  
+* name: "String"
+
   The name of the quota object. Useful for managing quotas and using queries for searching.
 
 * types: "String[]"
-  
-  A list of all the type names as defined in the "JMAP Types Names" registry (e.g., Email, Calendar, etc.) to which this quota applies. 
+
+  A list of all the type names as defined in the "JMAP Types Names" registry (e.g., Email, Calendar, etc.) to which this quota applies.
 This allows to assign quotas to distinct or shared data types.
 
 The server MUST filter out any types for which the client did not request the associated capability in the "using" section of the request.
@@ -42,40 +42,40 @@ Further, the server MUST NOT return Quota objects for which there are no types r
 
 The quota object MAY contain the following fields:
 
-* warnLimit: "UnsignedInt|null" 
-  
-  The warn limit set by this quota object, using the "resourceType" defined as unit of measure. 
-It can be used to send a warning to an entity about to reach the hard limit soon, but with no action taken yet. If set, it 
+* warnLimit: "UnsignedInt|null"
+
+  The warn limit set by this quota object, using the "resourceType" defined as unit of measure.
+It can be used to send a warning to an entity about to reach the hard limit soon, but with no action taken yet. If set, it
 SHOULD be lower than the "softLimit" (if present and different from null) and the "hardLimit".
 
-* softLimit: "UnsignedInt|null" 
-  
+* softLimit: "UnsignedInt|null"
+
   The soft limit set by this quota object, using the "resourceType" defined as unit of measure.
 It can be used to still allow some operations, but refuse some others. What is allowed or not is up to the server. For example, it
 could be used for blocking outgoing events of an entity (sending emails, creating calendar events, ...) while still receiving
-incoming events (receiving emails, receiving calendars events, ...). If set, it SHOULD be higher than the "warnLimit" 
+incoming events (receiving emails, receiving calendars events, ...). If set, it SHOULD be higher than the "warnLimit"
 (if present and different from null) but lower than the "hardLimit".
 
-* description: "String|null" 
-  
+* description: "String|null"
+
   Arbitrary free, human-readable, description of this quota. It might be used to explain
-where the different limits come from and explain the entities and data types this quota applies to. The description MUST be 
-encoded in UTF-8 [@!RFC3629] as described in [@!RFC8620] section 1.5, selected based on an Accept-Language header in the request
-(as defined in [@!RFC9110], Section 12.5.4) or out-of-band information about the user's language/locale.
+where the different limits come from and explain the entities and data types this quota applies to. The description MUST be
+encoded in UTF-8 [RFC3629](https://www.rfc-editor.org/rfc/rfc3629) as described in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620) section 1.5, selected based on an Accept-Language header in the request
+(as defined in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110), Section 12.5.4) or out-of-band information about the user's language/locale.
 
 The following JMAP methods are supported.
 
 ## Quota/get
 
-Standard "/get" method as described in [@!RFC8620] section 5.1. The *ids* argument may be "null" to fetch all Quotas of the account 
+Standard "/get" method as described in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620) section 5.1. The *ids* argument may be "null" to fetch all Quotas of the account
 at once, as demonstrated in this document in (#fetching-quotas).
 
 ## Quota/changes
 
-Standard "/changes" method as described in [@!RFC8620] section 5.2 but with one extra argument in the response:
+Standard "/changes" method as described in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620) section 5.2 but with one extra argument in the response:
 
-* updatedProperties: "String[]|null" 
-  
+* updatedProperties: "String[]|null"
+
   If only the "used" Quota property has changed since the old state, this
 will be a list containing only that property. If the server is unable to tell if only "used" has changed, it
 MUST be null.
@@ -91,25 +91,25 @@ This method's usage is demonstrated in this document at (#requesting-latest-quot
 
 ## Quota/query
 
-This is a standard "/query" method as described in [@!RFC8620], Section 5.5.
+This is a standard "/query" method as described in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 5.5.
 
 A **FilterCondition** object has the following properties, any of which may be included or  omitted:
 
-* name: "String" 
-  
-  The Quota _name_ property contains the given string.
+* name: "String"
 
-* scope: "String" 
-  
-  The Quota _scope_ property must match the given value exactly.
+  The Quota *name* property contains the given string.
 
-* resourceType: "String" 
-  
-  The Quota _resourceType_ property must match the given value exactly.
+* scope: "String"
 
-* type: "String" 
-  
-  The Quota _types_ property contains the given value.
+  The Quota *scope* property must match the given value exactly.
+
+* resourceType: "String"
+
+  The Quota *resourceType* property must match the given value exactly.
+
+* type: "String"
+
+  The Quota *types* property contains the given value.
 
 A Quota object matches the FilterCondition if and only if all the given conditions
 match. If zero properties are specified, it is automatically true for all objects.
@@ -121,7 +121,7 @@ The following Quota properties MUST be supported for sorting:
 
 ## Quota/queryChanges
 
-This is a standard "/queryChanges" method as described in [@!RFC8620], Section 5.6.
+This is a standard "/queryChanges" method as described in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 5.6.
 
 # Examples
 
@@ -205,5 +205,5 @@ With response:
 
 # Push
 
-Servers MUST support the JMAP push mechanisms, as specified in [@!RFC8620] Section 7, to allow clients to receive 
+Servers MUST support the JMAP push mechanisms, as specified in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620) Section 7, to allow clients to receive
 notifications when the state changes for the Quota type defined in this specification.

--- a/spec/quotas/securityconsiderations.mdown
+++ b/spec/quotas/securityconsiderations.mdown
@@ -1,19 +1,19 @@
 # Security considerations
 
-All security considerations of JMAP ([@!RFC8620]) apply to this specification.
+All security considerations of JMAP ([RFC8620](https://www.rfc-editor.org/rfc/rfc8620)) apply to this specification.
 
-Implementors should be careful to make sure the implementation of the extension specified in this document does not violate the site's 
+Implementors should be careful to make sure the implementation of the extension specified in this document does not violate the site's
 security policy. The resource usage of other users is likely to be considered confidential information and should not be divulged to
-unauthorized persons. 
+unauthorized persons.
 
 As for any resource shared across users (for example, a quota with the "domain" or "global" scope), a user that can consume
-the resource can affect the resources available to the other users. For example, a user could spam themselves with events and 
-make the shared resource hit the limit and unusable for others (implementors could mitigate that with some rate limiting 
+the resource can affect the resources available to the other users. For example, a user could spam themselves with events and
+make the shared resource hit the limit and unusable for others (implementors could mitigate that with some rate limiting
 implementation on the server).
 
-Also, revealing domain and global quota counts to all users may cause privacy leakage of other sensitive data, 
+Also, revealing domain and global quota counts to all users may cause privacy leakage of other sensitive data,
 or at least the existence of other sensitive data. For example, some users are part of a private list
 belonging to the server, so they shouldn't know how many users are in there. But by comparing the quota count
-before and after sending a message to the list, it could reveal the number of people of the list, as the 
-domain or global quota count would go up by the number of people subscribed. In order to limit those attacks, quotas with 
+before and after sending a message to the list, it could reveal the number of people of the list, as the
+domain or global quota count would go up by the number of people subscribed. In order to limit those attacks, quotas with
 "domain" or "global" scope SHOULD only be visible to server administrators and not to general users.

--- a/spec/sharing/intro.mdown
+++ b/spec/sharing/intro.mdown
@@ -1,24 +1,24 @@
 # Introduction
 
-JMAP ([@!RFC8620] – JSON Meta Application Protocol) is a generic protocol for synchronizing data, such as mail, calendars or contacts, between a client and a server. It is optimized for mobile and web environments, and aims to provide a consistent interface to different data types.
+JMAP ([RFC8620](https://www.rfc-editor.org/rfc/rfc8620) – JSON Meta Application Protocol) is a generic protocol for synchronizing data, such as mail, calendars or contacts, between a client and a server. It is optimized for mobile and web environments, and aims to provide a consistent interface to different data types.
 
 This specification defines a data model to represent entities in a collaborative environment and a framework for sharing data between them that can be used to provide a consistent sharing model for different data types. It does not define *what* may be shared, or the granularity of permissions, as this will depend on the data in question.
 
 ## Notational Conventions
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in BCP 14 [@!RFC2119] [@!RFC8174] when, and only when, they appear in all capitals, as shown here.
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in BCP 14 [RFC2119](https://www.rfc-editor.org/rfc/rfc2119) [RFC8174](https://www.rfc-editor.org/rfc/rfc8174) when, and only when, they appear in all capitals, as shown here.
 
-Type signatures, examples, and property descriptions in this document follow the conventions established in Section 1.1 of [@!RFC8620].  Data types defined in the core specification are also used in this document.
+Type signatures, examples, and property descriptions in this document follow the conventions established in Section 1.1 of [RFC8620](https://www.rfc-editor.org/rfc/rfc8620).  Data types defined in the core specification are also used in this document.
 
 ## Terminology
 
-The same terminology is used in this document as in the core JMAP specification, see [@!RFC8620], Section 1.6.
+The same terminology is used in this document as in the core JMAP specification, see [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 1.6.
 
 The terms Principal, and ShareNotification (with these specific capitalizations) are used to refer to the data types defined in this document and instances of those data types.
 
 ## Data Model Overview
 
-A Principal (see Section XXX) represents an individual, team, or resource (e.g., a room or projector). The object contains information about the entity being represented, such as a name, description, and time zone. It may also hold domain-specific information. A Principal may be associated with zero or more Accounts (see [@!RFC8620], Section 1.6.2) containing data belonging to the principal. Managing the set of principals within a system is out of scope for this specification, as it is highly domain specific. It is likely to map directly from a directory service or other user management system.
+A Principal (see Section XXX) represents an individual, team, or resource (e.g., a room or projector). The object contains information about the entity being represented, such as a name, description, and time zone. It may also hold domain-specific information. A Principal may be associated with zero or more Accounts (see [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 1.6.2) containing data belonging to the principal. Managing the set of principals within a system is out of scope for this specification, as it is highly domain specific. It is likely to map directly from a directory service or other user management system.
 
 Data types may allow users to share data with others by assigning permissions to principals. When a user's permissions are changed, a ShareNotification object is created for them so a client can inform the user of the changes.
 
@@ -26,7 +26,7 @@ Data types may allow users to share data with others by assigning permissions to
 
 Permissions determine whether a user *may* access data, but not whether they *want* to. Some shared data is of equal importance as the user's own, while other data is just there should the user wish to explicitly go find it. Clients will often want to differentiate the two; for example, a company may share mailing list archives for all departments with all employees, but a user may only generally be interested in the few they belong to. They would have *permission* to access many mailboxes, but can *subscribe* to just the ones they care about. The client would provide separate interfaces for reading mail in subscribed mailboxes and browsing all mailboxes they have permission to access in order to manage their subscriptions.
 
-The JMAP Session object (see [@!RFC8620], Section 2) typically includes an object in the `accounts` property for every account that the user has access to. Collaborative systems may share data between a very large number of Principals, most of which the user does not care about day-to-day. The Session object MUST only include Accounts where either the user is subscribed to at least one record (see [@!RFC8620], Section 1.6.3) in the account, or the account belongs to the user. StateChange events for changes to data SHOULD only be sent for data the user has subscribed to and MUST NOT be sent for any account where the user is not subscribed to any records in the account, except where that account belongs to the user.
+The JMAP Session object (see [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 2) typically includes an object in the `accounts` property for every account that the user has access to. Collaborative systems may share data between a very large number of Principals, most of which the user does not care about day-to-day. The Session object MUST only include Accounts where either the user is subscribed to at least one record (see [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 1.6.3) in the account, or the account belongs to the user. StateChange events for changes to data SHOULD only be sent for data the user has subscribed to and MUST NOT be sent for any account where the user is not subscribed to any records in the account, except where that account belongs to the user.
 
 The server MAY reject the user's attempt to subscribe to some resources even if they have permission to access them, e.g., a calendar representing a location.
 
@@ -34,7 +34,7 @@ A user may query the set of Principals they have access to with "Principal/query
 
 ## Addition to the Capabilities Object
 
-The capabilities object is returned as part of the JMAP Session object; see [@!RFC8620], Section 2. This document defines two additional capability URIs.
+The capabilities object is returned as part of the JMAP Session object; see [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 2. This document defines two additional capability URIs.
 
 ### urn:ietf:params:jmap:principals
 

--- a/spec/sharing/principal.mdown
+++ b/spec/sharing/principal.mdown
@@ -33,15 +33,15 @@ A **Principal** object has the following properties:
 
 ## Principal/get
 
-This is a standard "/get" method as described in [@!RFC8620], Section 5.1.
+This is a standard "/get" method as described in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 5.1.
 
 ## Principal/changes
 
-This is a standard "/changes" method as described in [@!RFC8620], Section 5.2.
+This is a standard "/changes" method as described in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 5.2.
 
 ## Principal/set
 
-This is a standard "/set" method as described in [@!RFC8620], Section 5.3.
+This is a standard "/set" method as described in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 5.3.
 
 Users SHOULD be allowed to update the "name", "description" and "timeZone" properties of the Principal with the same id as the "currentUserPrincipalId" in the Account capabilities.
 
@@ -49,7 +49,7 @@ However, the server may, and probably will, reject any change with a `forbidden`
 
 ## Principal/query
 
-This is a standard "/query" method as described in [@!RFC8620], Section 5.5
+This is a standard "/query" method as described in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 5.5
 
 ### Filtering
 
@@ -72,4 +72,4 @@ All conditions in the FilterCondition object must match for the Principal to mat
 
 ## Principal/queryChanges
 
-This is a standard "/queryChanges" method as described in [@!RFC8620], Section 5.6.
+This is a standard "/queryChanges" method as described in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 5.6.

--- a/spec/sharing/securityconsiderations.mdown
+++ b/spec/sharing/securityconsiderations.mdown
@@ -1,6 +1,6 @@
 # Security Considerations
 
-All security considerations of JMAP [@!RFC8620] apply to this specification. Additional considerations are detailed below.
+All security considerations of JMAP [RFC8620](https://www.rfc-editor.org/rfc/rfc8620) apply to this specification. Additional considerations are detailed below.
 
 ## Spoofing
 
@@ -13,6 +13,7 @@ Sharing data with another user allows someone to turn a transitory account compr
 ## Unauthorised principals
 
 The set of principals within a shared environment SHOULD be strictly controlled. If adding a new principal is open to the public, risks include:
+
 * An increased risk of a user accidentally sharing data with an unintended
   person.
 * An attacker may share unwanted or offensive information with the user.

--- a/spec/sharing/sharenotifications.mdown
+++ b/spec/sharing/sharenotifications.mdown
@@ -44,22 +44,22 @@ The **ShareNotification** object has the following properties:
 
 ## ShareNotification/get
 
-This is a standard "/get" method as described in [@!RFC8620], Section 5.1.
+This is a standard "/get" method as described in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 5.1.
 
 ## ShareNotification/changes
 
-This is a standard "/changes" method as described in [@!RFC8620], Section 5.2.
+This is a standard "/changes" method as described in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 5.2.
 
 ## ShareNotification/set
 
-This is a standard "/set" method as described in [@!RFC8620], Section 5.3.
+This is a standard "/set" method as described in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 5.3.
 
 Only destroy is supported; any attempt to create/update MUST be rejected with a
 `forbidden` SetError.
 
 ## ShareNotification/query
 
-This is a standard "/query" method as described in [@!RFC8620], Section 5.5.
+This is a standard "/query" method as described in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 5.5.
 
 ### Filtering
 
@@ -80,4 +80,4 @@ The "created" property MUST be supported for sorting.
 
 ## ShareNotification/queryChanges
 
-This is a standard "/queryChanges" method as described in [@!RFC8620], Section 5.6.
+This is a standard "/queryChanges" method as described in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 5.6.

--- a/spec/tasks/intro.mdown
+++ b/spec/tasks/intro.mdown
@@ -1,6 +1,6 @@
 # Introduction
 
-JMAP ([@!RFC8620] – JSON Meta Application Protocol) is a generic protocol for synchronizing data, such as mail, calendars or contacts, between a client and a server. It is optimized for mobile and web environments, and aims to provide a consistent interface to different data types.
+JMAP ([RFC8620](https://www.rfc-editor.org/rfc/rfc8620) – JSON Meta Application Protocol) is a generic protocol for synchronizing data, such as mail, calendars or contacts, between a client and a server. It is optimized for mobile and web environments, and aims to provide a consistent interface to different data types.
 
 JMAP for Calendars ([@!I-D.ietf-jmap-calendars]) defines a data model for synchronizing calendar data between a client and a server using JMAP. The data model is designed to allow a server to provide consistent access to the same data via CalDAV [@?RFC4791] as well as JMAP.
 
@@ -8,37 +8,37 @@ While CalDAV defines access to tasks, JMAP for Calendars does not. This specific
 
 ## Notational Conventions
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in BCP 14 [@!RFC2119] [@!RFC8174] when, and only when, they appear in all capitals, as shown here.
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in BCP 14 [RFC2119](https://www.rfc-editor.org/rfc/rfc2119) [RFC8174](https://www.rfc-editor.org/rfc/rfc8174) when, and only when, they appear in all capitals, as shown here.
 
-Type signatures, examples, and property descriptions in this document follow the conventions established in Section 1.1 of [@!RFC8620].  Data types defined in the core specification are also used in this document.
+Type signatures, examples, and property descriptions in this document follow the conventions established in Section 1.1 of [RFC8620](https://www.rfc-editor.org/rfc/rfc8620).  Data types defined in the core specification are also used in this document.
 
 ## The LocalDate Data Type
 
-Where `LocalDate` is given as a type, it means a string in the same format as `Date` (see [@!RFC8620], Section 1.4), but with the `time-offset` omitted from the end. For example, `2014-10-30T14:12:00`. The interpretation in absolute time depends upon the time zone for the task, which may not be a fixed offset (for example when daylight saving time occurs).
+Where `LocalDate` is given as a type, it means a string in the same format as `Date` (see [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 1.4), but with the `time-offset` omitted from the end. For example, `2014-10-30T14:12:00`. The interpretation in absolute time depends upon the time zone for the task, which may not be a fixed offset (for example when daylight saving time occurs).
 
 ## The Duration Data Type
 
-Where `Duration` is given as a type, it means a length of time represented by a subset of the ISO 8601 duration format, as defined in [@!RFC8984], Section 1.4.6.
+Where `Duration` is given as a type, it means a length of time represented by a subset of the ISO 8601 duration format, as defined in [RFC8984](https://www.rfc-editor.org/rfc/rfc8984), Section 1.4.6.
 
 ## Terminology
 
-The same terminology is used in this document as in the core JMAP specification, see [@!RFC8620], Section 1.6.
+The same terminology is used in this document as in the core JMAP specification, see [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 1.6.
 
 The terms ParticipantIdentity, TaskList, Task and TaskNotification are used to refer to the data types defined in this document and instances of those data types.
 
 ## Data Model Overview
 
-Similar to JMAP for Calendar, an Account (see [@!RFC8620], Section 1.6.2) contains zero or more TaskList objects, which is a named collection of Tasks belonging to a Principal (see [@!I-D.ietf-jmap-sharing] Section XXX). Task lists can also provide defaults, such as alerts and a color, to apply to tasks in the calendar. Clients commonly let users toggle visibility of tasks belonging to a particular task list on/off.
+Similar to JMAP for Calendar, an Account (see [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 1.6.2) contains zero or more TaskList objects, which is a named collection of Tasks belonging to a Principal (see [@!I-D.ietf-jmap-sharing] Section XXX). Task lists can also provide defaults, such as alerts and a color, to apply to tasks in the calendar. Clients commonly let users toggle visibility of tasks belonging to a particular task list on/off.
 
-A Task is a representation of a single task or recurring series of Tasks in JSTask [@!RFC8984] format. Recurrence rules and alerts as defined in JMAP for Calendars (see [@!I-D.ietf-jmap-calendars] Section XXX) apply.
+A Task is a representation of a single task or recurring series of Tasks in JSTask [RFC8984](https://www.rfc-editor.org/rfc/rfc8984) format. Recurrence rules and alerts as defined in JMAP for Calendars (see [@!I-D.ietf-jmap-calendars] Section XXX) apply.
 
 Just like the CalendarEventNotification objects (see [@!I-D.ietf-jmap-calendars] Section XXX), TaskNotification objects keep track of the history of changes made to a task by other users. Similarly, the ShareNotification type (see [@!I-D.ietf-jmap-sharing] Section XXX) notifies the user when their access to another user's task list is granted or revoked.
 
-Use cases for task systems vary. Only a few systems will require implementation of all available features defined within this specification. For this reason, this document describes several extensions to the core task properties and objects through which support for a certain feature MUST be advertised via capabilities. In addition to the core features advertised via `urn:ietf:params:jmap:tasks` support for recurrences, assignees, alerts, localizations as well as custom time zones can be advertised. As defined in [@!RFC8620], servers SHOULD throw an "urn:ietf:params:jmap:error:unknownCapability" error when a client uses a capability that the server does not understand. However, a Task object might just contain data that the server does not understand. In this case, the server SHOULD save it and ignore its existence.
+Use cases for task systems vary. Only a few systems will require implementation of all available features defined within this specification. For this reason, this document describes several extensions to the core task properties and objects through which support for a certain feature MUST be advertised via capabilities. In addition to the core features advertised via `urn:ietf:params:jmap:tasks` support for recurrences, assignees, alerts, localizations as well as custom time zones can be advertised. As defined in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), servers SHOULD throw an "urn:ietf:params:jmap:error:unknownCapability" error when a client uses a capability that the server does not understand. However, a Task object might just contain data that the server does not understand. In this case, the server SHOULD save it and ignore its existence.
 
 ## Addition to the Capabilities Object
 
-The capabilities object is returned as part of the JMAP Session object; see [@!RFC8620], Section 2. This document defines six additional capability URIs.
+The capabilities object is returned as part of the JMAP Session object; see [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 2. This document defines six additional capability URIs.
 
 ### urn:ietf:params:jmap:tasks
 

--- a/spec/tasks/list.mdown
+++ b/spec/tasks/list.mdown
@@ -9,8 +9,8 @@ A **TaskList** object has the following core properties:
 - **role**: `String|null` (default: null)
   Denotes the task list has a special purpose. This MUST be one of the following:
 
-    - `inbox`: This is the principal's default task list;
-    - `trash`: This task list holds messages the user has discarded;
+  - `inbox`: This is the principal's default task list;
+  - `trash`: This task list holds messages the user has discarded;
 
 - **name**: `String`
   The user-visible name of the task list. This may be any UTF-8 string of at least 1 character in length and maximum 255 octets in size.
@@ -44,14 +44,14 @@ A **TaskList** object has the following core properties:
 - **timeZone**: `String|null` (default: null)
   The time zone to use for tasks without a time zone when the server needs to resolve them into absolute time, e.g., for alerts or availability calculation. The value MUST be a time zone id from the IANA Time Zone Database [TZDB](https://www.iana.org/time-zones). If `null`, the timeZone of the account's associated Principal will be used. Clients SHOULD use this as the default for new tasks in this task list, if set.
 - **workflowStatuses**: `String[]` (default: [completed, failed, in-process, needs-action, cancelled, pending])
-  Defines the allowed values for `workflowStatus`. The default values are based on the values defined within [@!RFC8984], Section 5.2.5 and `pending`. `pending` indicates the task has been created and accepted, but it currently is on-hold.
+  Defines the allowed values for `workflowStatus`. The default values are based on the values defined within [RFC8984](https://www.rfc-editor.org/rfc/rfc8984), Section 5.2.5 and `pending`. `pending` indicates the task has been created and accepted, but it currently is on-hold.
 
     As naming and workflows differ between systems, mapping the status correctly to the present values of the Task can be challenging. In the most simple case, a task system may support merely two states - done and not-done. On the other hand, statuses and their semantic meaning can differ between systems or task lists (e.g. projects). In case of uncertainty, here are some recommendations for mapping commonly observed values that can help during implementation:
 
-    - `completed`: `done` (most simple case), `closed`, `verified`, …
-    - `in-process`: `in-progress`, `active`, `assigned`, …
-    - `needs-action`: `not-done` (most simple case), `not-started`, `new`, …
-    - `pending`: `waiting`, `deferred`, `on-hold`, `paused`, …
+  - `completed`: `done` (most simple case), `closed`, `verified`, …
+  - `in-process`: `in-progress`, `active`, `assigned`, …
+  - `needs-action`: `not-done` (most simple case), `not-started`, `new`, …
+  - `pending`: `waiting`, `deferred`, `on-hold`, `paused`, …
 
 - **shareWith**: `Id[TaskRights]|null` (default: null)
   A map of Principal id to rights for principals this task list is shared with. The principal to which this task list belongs MUST NOT be in this set. This is null if the task list  is not shared with anyone. May be modified only if the user has the mayAdmin right. The account id for the principals may be found in the `urn:ietf:params:jmap:principals:owner` capability of the Account to which the task list belongs.
@@ -83,9 +83,9 @@ A **TaskRights** object has the following properties:
 - **mayRSVP**: `Boolean`
   The user may modify the following properties of any Participant object that corresponds to one of the user's ParticipantIdentity objects in the account, even if they would not otherwise have permission to modify that task
 
-    - participationStatus
-    - participationComment
-    - expectReply
+  - participationStatus
+  - participationComment
+  - expectReply
 
     If the task has its "mayInviteSelf" property set to true (see Section XXX), then the user may also add a new Participant to the task with a sendTo property that is the same as the sendTo property of one of the user's ParticipantIdentity objects in the account. The roles property of the participant MUST only contain "attendee".
 
@@ -102,7 +102,7 @@ The user is an **owner** for a task if the Task object has a "participant" prope
 
 1. Has the "chair" role.
 1. Corresponds to one of the user's ParticipantIdentity objects in the account (as per Section XXX).
-  
+
 A task has no owner if its participant property is null or omitted.
 
 ## Alerts extension
@@ -110,30 +110,30 @@ A task has no owner if its participant property is null or omitted.
 A TaskList has the following alerts properties:
 
 - **defaultAlertsWithTime**: `Id[Alert]|null`
-  A map of alert ids to Alert objects (see [@!RFC8984], Section 4.5.2) to apply for tasks where "showWithoutTime" is false and "useDefaultAlerts" is true. Ids MUST be unique across all default alerts in the account, including those in other task lists; a UUID is recommended.
+  A map of alert ids to Alert objects (see [RFC8984](https://www.rfc-editor.org/rfc/rfc8984), Section 4.5.2) to apply for tasks where "showWithoutTime" is false and "useDefaultAlerts" is true. Ids MUST be unique across all default alerts in the account, including those in other task lists; a UUID is recommended.
 
     If omitted on creation, the default is server dependent. For example, servers may choose to always default to `null`, or may copy the alerts from the default task list.
 
 - **defaultAlertsWithoutTime**: `Id[Alert]|null`
-  A map of alert ids to Alert objects (see [@!RFC8984], Section 4.5.2) to apply for tasks where "showWithoutTime" is true and "useDefaultAlerts" is true. Ids MUST be unique across all default alerts in the account, including those in other task lists; a UUID is recommended.
+  A map of alert ids to Alert objects (see [RFC8984](https://www.rfc-editor.org/rfc/rfc8984), Section 4.5.2) to apply for tasks where "showWithoutTime" is true and "useDefaultAlerts" is true. Ids MUST be unique across all default alerts in the account, including those in other task lists; a UUID is recommended.
 
       If omitted on creation, the default is server dependent. For example, servers may choose to always default to `null`, or may copy the alerts from the default task list.
 
 ## TaskList/get
 
-This is a standard "/get" method as described in [@!RFC8620], Section 5.1. The *ids* argument may be `null` to fetch all at once.
+This is a standard "/get" method as described in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 5.1. The *ids* argument may be `null` to fetch all at once.
 
 ## TaskList/changes
 
-This is a standard "/changes" method as described in [@!RFC8620], Section 5.2.
+This is a standard "/changes" method as described in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 5.2.
 
 ## TaskList/set
 
-This is the standard "/set" method as described in [@!RFC8620], Section 5.3 but with the following additional request argument:
+This is the standard "/set" method as described in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 5.3 but with the following additional request argument:
 
 - **onDestroyRemoveTasks**: `Boolean` (default: false)
 
-  If false, any attempt to destroy a TaskList that still has Tasks 
+  If false, any attempt to destroy a TaskList that still has Tasks
   in it will be rejected with a `TaskListHasTask` SetError. If
   true, any Tasks that were in the TaskList will be removed from it, and they will be destroyed.
 

--- a/spec/tasks/principal.mdown
+++ b/spec/tasks/principal.mdown
@@ -13,4 +13,4 @@ A "urn:ietf:params:jmap:tasks" property is added to the Principal "capabilities"
   May the user add this principal as a task sharee (by adding them to the
   shareWith property of a task list, see Section XXX)?
 - **sendTo**: `String[String]|null`
-  If this principal may be added as a participant to a task, this is the Participant#sendTo property to add (see [@!RFC8984], Section 4.4.5) for scheduling messages to reach it.
+  If this principal may be added as a participant to a task, this is the Participant#sendTo property to add (see [RFC8984](https://www.rfc-editor.org/rfc/rfc8984), Section 4.4.5) for scheduling messages to reach it.

--- a/spec/tasks/securityconsiderations.mdown
+++ b/spec/tasks/securityconsiderations.mdown
@@ -1,3 +1,3 @@
 # Security Considerations
 
-All security considerations of JMAP [@!RFC8620] and JSCalendar [@!RFC8984] apply to this specification. Additional considerations specific to the data types and functionality introduced by this document are described in the following subsections.
+All security considerations of JMAP [RFC8620](https://www.rfc-editor.org/rfc/rfc8620) and JSCalendar [RFC8984](https://www.rfc-editor.org/rfc/rfc8984) apply to this specification. Additional considerations specific to the data types and functionality introduced by this document are described in the following subsections.

--- a/spec/tasks/task.mdown
+++ b/spec/tasks/task.mdown
@@ -1,6 +1,6 @@
 # Tasks
 
-A **Task** object contains information about a task. It is a JSTask object, as defined in [@!RFC8984]. However, as use-cases of task systems vary, this Section defines relevant parts of the JSTask object to implement the core task capability as well as several extensions to it. Only the core capability MUST be implemented by any task system. Implementers can choose the extensions that fit their own use case. For example, the recurrence extension allows having a Task object represent a series of recurring Tasks.
+A **Task** object contains information about a task. It is a JSTask object, as defined in [RFC8984](https://www.rfc-editor.org/rfc/rfc8984). However, as use-cases of task systems vary, this Section defines relevant parts of the JSTask object to implement the core task capability as well as several extensions to it. Only the core capability MUST be implemented by any task system. Implementers can choose the extensions that fit their own use case. For example, the recurrence extension allows having a Task object represent a series of recurring Tasks.
 
 The core JSTask objects are Task, Link, Location, Relation and VirtualLocation. The core properties are JSTask's Metadata Properties (Section 4.1), What and Where Properties (Section 4.2), Task Properties (Section 5.2) as well as priority (Section 4.4.1), privacy (Section 4.4.3), replyTo (Section 4.4.4) and timeZone (Section 4.7.1).
 
@@ -76,33 +76,33 @@ Type: `Id[Checklist]`
 
 A map of Checklist IDs to Checklist objects, containing checklist items. A **Checklist** object has the following properties:
 
-* **@type**: `String`
+- **@type**: `String`
   Specifies the type of this object. This MUST be `Checklist`.
-* **title**: `String` (optional)
-  Title of the list. 
-* **checkItems**: `CheckItem[]` (optional)
+- **title**: `String` (optional)
+  Title of the list.
+- **checkItems**: `CheckItem[]` (optional)
   The items of the check list.
 
 A **CheckItem** object has the following properties:
 
-* **@type**: `String`
+- **@type**: `String`
   Specifies the type of this object. This MUST be `CheckItem`.
-* **title**: `String`
+- **title**: `String`
   Title of the item.
-* **sortOrder**: `UnsignedInt` (default: 0)
+- **sortOrder**: `UnsignedInt` (default: 0)
   Defines the sort order of CheckItem when presented in the client's UI. The number MUST be an integer in the range 0 <= sortOrder < 2^31. An item with a lower order should be displayed before an item with a higher order. Items with equal order SHOULD be sorted in alphabetical order by name. The sorting should take into account locale-specific character order convention.
-* **updated**: `UTCDateTime` (optional)
+- **updated**: `UTCDateTime` (optional)
   The date and time when this item was updated
-* **isComplete**: `Boolean`
-* **assigneee**: `Person` (optional)
+- **isComplete**: `Boolean`
+- **assigneee**: `Person` (optional)
   The person that this item is assigned to. The Person object has the following properties of which either principalId or uri MUST be defined:
-  * **@type**: `String` (mandatory)
+  - **@type**: `String` (mandatory)
     Specifies the type of this object. This MUST be Person.
-  * **name**: `String` (optional)
+  - **name**: `String` (optional)
     The name of the person.
-  * **uri**: `String` (optional)
+  - **uri**: `String` (optional)
     A URI value that identifies the person. This SHOULD be the scheduleId of the participant that this item was assigned to.
-  * **principalId**: `String` (optional)
+  - **principalId**: `String` (optional)
     The id of the Principal corresponding to the person, if any.
 
 ### comments
@@ -111,11 +111,11 @@ Type: `Id[Comment]` (optional).
 
 Free-text comments associated with this task. A Comment object has the following properties:
 
-* **@type**: `String` (mandatory). Specifies the type of this object. This MUST be `Comment`.
-* **message**: `String` (mandatory). The free text value of this comment.
-* **created**: `UTCDateTime` (optional). The date and time when this note was created.
-* **updated**: `UTCDateTime` (optional). The date and time when this note was updated.
-* **author**: `Person` (optional). The author of this comment. The Person object is defined in Section (#checklists).
+- **@type**: `String` (mandatory). Specifies the type of this object. This MUST be `Comment`.
+- **message**: `String` (mandatory). The free text value of this comment.
+- **created**: `UTCDateTime` (optional). The date and time when this note was created.
+- **updated**: `UTCDateTime` (optional). The date and time when this note was updated.
+- **author**: `Person` (optional). The author of this comment. The Person object is defined in Section (#checklists).
 
 ## Properties similar in JMAP for Calendar
 
@@ -145,11 +145,11 @@ The Task will require the following further property:
   scheduling for this task; the task has not been added as a result of an
   invitation from another task management system)? This is `true` if, and only if:
 
-    * the task's "replyTo" property is `null`; or
-    * the account will receive messages sent to at least one of the methods
+  - the task's "replyTo" property is `null`; or
+  - the account will receive messages sent to at least one of the methods
       specified in the "replyTo" property of the task.
 
-Task objects MUST NOT have a "method" property as this is only used when representing iTIP [@!RFC5546] scheduling messages, not tasks in a data store.
+Task objects MUST NOT have a "method" property as this is only used when representing iTIP [RFC5546](https://www.rfc-editor.org/rfc/rfc5546) scheduling messages, not tasks in a data store.
 
 ### Per-user properties
 
@@ -170,6 +170,7 @@ When writing only per-user properties, the "updated" property MUST also be store
 The assignees extension extends one JSCalendar data type with new values.
 
 #### Participants
+
 The Participant object, as defined in [@!I-D.ietf-calext-jscalendar] Section 4.4.6 is used to represent participants. This spec extends the keys for the roles property with the following value:
 
 - `assignee`: the participant is expected to work on the task
@@ -218,7 +219,7 @@ TODO redefine this here. Similar to "TaskList/get" we only need to replace a few
 
 ## Task/changes
 
-This is a standard "/changes" method as described in [@!RFC8620], Section 5.2.
+This is a standard "/changes" method as described in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 5.2.
 
 ## Task/set
 
@@ -228,7 +229,7 @@ TODO copy+paste most stuff from "CalendarEvent/set". It should be fine to just r
 
 ## Task/copy
 
-This is a standard "/copy" method as described in [@!RFC8620], Section 5.4.
+This is a standard "/copy" method as described in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 5.4.
 
 ## Task/query
 
@@ -238,5 +239,5 @@ TODO copy+paste most stuff from "CalendarEvent/query". Mainly filtering should b
 
 ## Task/queryChanges
 
-This is a standard "/queryChanges" method as described in [@!RFC8620], Section 5.6.
+This is a standard "/queryChanges" method as described in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 5.6.
 s

--- a/spec/tasks/tasknotifications.mdown
+++ b/spec/tasks/tasknotifications.mdown
@@ -37,22 +37,22 @@ If the change only affects a single instance of a recurring task, the server MAY
 
 ## TaskNotification/get
 
-This is a standard "/get" method as described in [@!RFC8620], Section 5.1.
+This is a standard "/get" method as described in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 5.1.
 
 ## TaskNotification/changes
 
-This is a standard "/changes" method as described in [@!RFC8620], Section 5.2.
+This is a standard "/changes" method as described in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 5.2.
 
 ## TaskNotification/set
 
-This is a standard "/set" method as described in [@!RFC8620], Section 5.3.
+This is a standard "/set" method as described in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 5.3.
 
 Only destroy is supported; any attempt to create/update MUST be rejected with a
 `forbidden` SetError.
 
 ## TaskNotification/query
 
-This is a standard "/query" method as described in [@!RFC8620], Section 5.5.
+This is a standard "/query" method as described in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 5.5.
 
 ### Filtering
 
@@ -73,4 +73,4 @@ The "created" property MUST be supported for sorting.
 
 ## TaskNotification/queryChanges
 
-This is a standard "/queryChanges" method as described in [@!RFC8620], Section 5.6.
+This is a standard "/queryChanges" method as described in [RFC8620](https://www.rfc-editor.org/rfc/rfc8620), Section 5.6.


### PR DESCRIPTION
I didn't see evidence of Markdown standards (i.e. no Markdownlint config, didn't seem to be any limits on line length, etc) but if these are documented let me know

Fixes: #395 