### PR TITLE
Add Missive to libraries list

### DIFF
--- a/software/software.mdown
+++ b/software/software.mdown
@@ -36,6 +36,7 @@
 * **[jmap-rs](https://gitlab.com/jmap-rs/jmap-rs)** (Rust; in development): Rust client (and maybe server) library for JMAP
 * **[jmapc](https://pypi.org/project/jmapc/)** (Python; [partially implemented](https://github.com/smkent/jmapc)): Python 3 client library for JMAP mail
 * **[melib](https://meli.delivery)** (Rust): mail client library used in *meli* (GPLv3)
+* **[Missive](https://github.com/jeffhuen/missive)** (Rust, MIT): Email library with JMAP provider. Minimal spec-compliant client using reqwest+serde.
 * **[zend-jmap](https://github.com/WikiSuite/zend-jmap)** (PHP, New BSD): JMAP for Zend Framework
 * **[jmap-yacl](https://github.com/ilyhalight/jmap-yacl)** (TypeScript, MIT): Another lightweight client library for working with the JMAP, which supports working with JavaScript, TypeScript, and also has built-in types for Typebox. Not implemented yet: OAuth, Push
 * **[calcard](https://github.com/stalwartlabs/calcard)** (Rust; Apache/MIT): JSCalendar/iCalendar and JSContact/vCard parsing, building and conversion library for Rust. Try it [online](https://convert.jmap.cloud/).


### PR DESCRIPTION
Adds [Missive](https://github.com/jeffhuen/missive) to the JMAP software libraries list.

Missive is a Rust email library with a JMAP provider that uses a minimal spec-compliant implementation built on reqwest+serde (no external JMAP crate dependencies).

Features:
- Works with any JMAP server (Stalwart, Fastmail, Cyrus, etc.)
- Basic auth and Bearer token (OAuth2) authentication
- Full RFC 8621 submission flow