### PR TITLE
Add JMAP Webmail to software list

### DIFF
--- a/software/software.mdown
+++ b/software/software.mdown
@@ -5,6 +5,7 @@
 * **[aerc](https://aerc-mail.org/)**: A terminal email client for the discerning hacker.
 * **[Cypht](https://github.com/cypht-org/cypht)**: (PHP, JS) Lightweight Open Source webmail aggregator
 * **[Group-Office](https://github.com/Intermesh/groupoffice)** (Javascript): Open source groupware and collaboration platform
+* **[JMAP Webmail](https://github.com/root-fr/jmap-webmail)** (TypeScript, MIT): A modern, privacy-focused webmail client built with Next.js. Features multi-language support, dark mode, 2FA, and full JMAP Mail/Calendar/Contacts.
 * **[JMAP Demo Webmail](https://github.com/jmapio/jmap-demo-webmail)** (JavaScript, MIT): a sophisticated demo webmail client to be used as a base for new projects.
 * **[JMAP::Tester](https://metacpan.org/pod/JMAP::Tester)** (Perl, Perl5): a JMAP client made for testing JMAP servers.
 * **[Ltt.rs](https://codeberg.org/iNPUTmice/lttrs-android)** (Java, Apache): an email client for Android


### PR DESCRIPTION
Adds [JMAP Webmail](https://github.com/root-fr/jmap-webmail) to the Clients section of the software page.

**JMAP Webmail** is an open-source (MIT), privacy-focused webmail client built with TypeScript and Next.js. It supports:

- Full JMAP Mail, Calendar, and Contacts
- Multi-language UI (8 languages)
- Dark mode
- Two-factor authentication (TOTP)
- OAuth2/OIDC with PKCE

It is designed to work with Stalwart Mail Server but compatible with any JMAP-compliant server.