### PR TITLE
Update jmap.io FAQ to link to RFC8949 for CBOR instead of RFC7049

### DIFF
--- a/home/faq.mdown
+++ b/home/faq.mdown
@@ -77,7 +77,7 @@
             <summary>Why use HTTPS/JSON?</summary>
             <p>The short answer is it's good enough, it's widely understood, and it's by far the easiest thing for developers to adopt. There's support in basically all OSes and programming languages. And it's easy to read and debug.</p>
             <p>HTTP doesn't tend to run into firewall issues, and is so commonly used that it has integrations which can help with optimisation (for example, iOS has built-in support for optimising radio usage by batching HTTP calls from different apps where possible, which their mail team have told us they would like to be able to use). This isn't an innate advantage of HTTP, but rather an advantage of its ubiquity.</p>
-            <p>With GZIP, JSON data is reasonably compact and fast enough to serialise/parse. However, the encoding/transport part of JMAP is not core to its operation, so future specifications could easily add alternatives (e.g. <a href="https://tools.ietf.org/html/rfc6455">WebSocket</a> instead of HTTPS, <a href="http://tools.ietf.org/html/rfc7049">CBOR</a> instead of JSON). For the initial version though, HTTPS+JSON makes the most sense.</p>
+            <p>With GZIP, JSON data is reasonably compact and fast enough to serialise/parse. However, the encoding/transport part of JMAP is not core to its operation, so future specifications could easily add alternatives (e.g. <a href="https://tools.ietf.org/html/rfc6455">WebSocket</a> instead of HTTPS, <a href="http://tools.ietf.org/html/rfc8949">CBOR</a> instead of JSON). For the initial version though, HTTPS+JSON makes the most sense.</p>
         </details>
         <details>
             <summary>Binary data</summary>


### PR DESCRIPTION
RFC7049 has been obsoleted by RFC8949