### PR TITLE
Clients: add jmapcli (native macOS JMAP command-line client)

### DIFF
--- a/software/software.mdown
+++ b/software/software.mdown
@@ -9,6 +9,7 @@
 * **[JMAP Demo Webmail](https://github.com/jmapio/jmap-demo-webmail)** (JavaScript, MIT): a sophisticated demo webmail client to be used as a base for new projects.
 * **[JMAP::Tester](https://metacpan.org/pod/JMAP::Tester)** (Perl, Perl5): a JMAP client made for testing JMAP servers.
 * **[JMAP Webmail](https://github.com/root-fr/jmap-webmail)** (TypeScript, MIT): Privacy-focused webmail client with real-time push.
+* **[jmapcli](https://boogie.digital/cli/)** (Swift, proprietary): A fast, native macOS command-line JMAP client. Send, read, search, sync and manage mail from the terminal; installs via Homebrew. Works with any JMAP server (Stalwart, Fastmail, Cyrus).
 * **[Ltt.rs](https://codeberg.org/iNPUTmice/lttrs-android)** (Java, Apache): an email client for Android
 * **[Mailtemi](https://mailtemi.com)**: a native iOS/Android email client
 * **[mjmap](https://git.sr.ht/~rockorager/mjmap)** (Go, MPL-2.0): A sendmail-compatible command line JMAP client.


### PR DESCRIPTION
Adds **jmapcli** to the Clients list — a fast, native macOS command-line JMAP client (Swift), installable via Homebrew. Works with any JMAP server (developed against Stalwart; also Fastmail, Cyrus).

- Website / docs: https://boogie.digital/cli/
- Install: `brew tap jasonhollis/boogie && brew install jmapcli`
- Repo: https://github.com/jasonhollis/jmapcli

It's the command-line companion to Boogie, the native JMAP email + calendar app for Apple platforms.