### PR TITLE
Clients: add Boogie (native JMAP email + calendar client for Apple platforms)

### DIFF
--- a/software/software.mdown
+++ b/software/software.mdown
@@ -3,6 +3,7 @@
 ## Clients
 
 * **[aerc](https://aerc-mail.org/)**: A terminal email client for the discerning hacker.
+* **[Boogie](https://boogie.digital/)** (Swift, proprietary): A native JMAP email and calendar client for Apple platforms — macOS, iOS, iPadOS and watchOS. Built from scratch in pure Swift with zero dependencies, privacy-first by default, designed for Stalwart Mail Server and open email standards.
 * **[Bulwark Webmail](https://bulwarkmail.org/)**: (Next.js, AGPLv3): A modern, open-source webmail client for Stalwart Mail Server. Fast and private JMAP-native support for email, calendar, and contacts.
 * **[Cypht](https://github.com/cypht-org/cypht)**: (PHP, JS) Lightweight Open Source webmail aggregator
 * **[Group-Office](https://github.com/Intermesh/groupoffice)** (Javascript): Open source groupware and collaboration platform


### PR DESCRIPTION
Adds **Boogie** to the Clients list — a native JMAP email and calendar client for Apple platforms (macOS, iOS, iPadOS and watchOS), written from scratch in pure Swift with zero dependencies and built for Stalwart Mail Server. It's available on the App Store.

This is the GUI sibling to **jmapcli**, the command-line client added in #433.

- Homepage: https://boogie.digital/
- One file changed: a single bullet under `## Clients`, placed alphabetically after `aerc`.
